### PR TITLE
New File (Cmd+N), Create an empty project

### DIFF
--- a/public/samples/claps/empty_project.clap
+++ b/public/samples/claps/empty_project.clap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42bb7d554f5209f9c0e801c3d71b3b11730f80a2c7a39cf4ac7baf94743d7be1
+size 375

--- a/public/samples/claps/empty_project.yaml
+++ b/public/samples/claps/empty_project.yaml
@@ -1,0 +1,24 @@
+- format: clap-0
+  numberOfEntities: 0
+  numberOfScenes: 0
+  numberOfSegments: 27
+- id: 5ffcfd0b-cb91-465e-87b6-bde41037373e
+  title: ""
+  description: An exciting new project
+  synopsis: ""
+  licence: ""
+  orientation: landscape
+  durationInMs: 18000
+  width: 1024
+  height: 575
+  defaultVideoModel: AnimateDiff-Lightning
+  extraPositivePrompt: []
+  screenplay: ""
+  isLoop: false
+  isInteractive: false
+- id: e16478cf-3535-48e9-98e8-f702ec9ca348
+  track: 0
+  startTimeInMs: 0
+  endTimeInMs: 0
+  category: video
+  outputType: video

--- a/src/components/toolbars/top-menu/file/index.tsx
+++ b/src/components/toolbars/top-menu/file/index.tsx
@@ -31,6 +31,8 @@ export function TopMenuFile() {
   const saveZipFile = useIO(s => s.saveZipFile)
   const saveKdenline = useIO(s => s.saveKdenline)
 
+  const hasBetaAccess = useUI(s => s.hasBetaAccess)
+
   useEffect(() => {
     (async () => {
       if (!clapUrl) {
@@ -55,6 +57,13 @@ export function TopMenuFile() {
     <MenubarMenu>
       <MenubarTrigger>File</MenubarTrigger>
       <MenubarContent>
+        {hasBetaAccess &&
+          <MenubarItem onClick={() => {
+            openClapUrl('/samples/claps/empty_project.clap')
+          }}>
+            New Project<MenubarShortcut>⌘N</MenubarShortcut>
+          </MenubarItem>
+        }
         <MenubarItem onClick={() => {
           openFilePicker()
         }}>


### PR DESCRIPTION
This PR adds a "New File" option. It is only visible in 'beta' mode. It loads an empty project. from the samples/clap directory.

I noticed that I needed at least one track for the project view to appear.

I considered creating a blank data structure in typescript but I think that using a template is better. In the future if the spec changes you could automate blank project generation without needing to change the code for it.