### PR TITLE
Add Examples menu to File menu

### DIFF
--- a/src/components/toolbars/top-menu/file/index.tsx
+++ b/src/components/toolbars/top-menu/file/index.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react"
 import { useTimeline } from "@aitube/timeline"
 import { useHotkeys } from "react-hotkeys-hook"
 
-import { MenubarContent, MenubarItem, MenubarMenu, MenubarSeparator, MenubarShortcut, MenubarTrigger } from "@/components/ui/menubar"
+import { MenubarContent, MenubarItem, MenubarMenu, MenubarSeparator, MenubarShortcut, MenubarSub, MenubarSubContent, MenubarSubTrigger, MenubarTrigger } from "@/components/ui/menubar"
 import { useOpenFilePicker, useQueryStringParams } from "@/lib/hooks"
 import { IframeWarning } from "@/components/dialogs/iframe-warning"
 import { useIO } from "@/services/io/useIO"
@@ -66,6 +66,17 @@ export function TopMenuFile() {
         }}>
           Save project (.clap)<MenubarShortcut>⌘S</MenubarShortcut>
         </MenubarItem>
+        <MenubarSeparator />
+        <MenubarSub>
+          <MenubarSubTrigger>Examples</MenubarSubTrigger>
+          <MenubarSubContent>
+            <MenubarItem onClick={() => {
+              openClapUrl('/samples/claps/wasteland.clap')
+            }}>
+              Wasteland
+            </MenubarItem>
+          </MenubarSubContent>
+        </MenubarSub>
         <MenubarSeparator />
         {/*
         <MenubarItem


### PR DESCRIPTION
This PR adds examples with a single-- "Wasteland".
More examples can be added in the future. If it gets crazy we can load a list from somewhere, but the goal here is to give new users an example of what Clapper can do quickly without them needing to go hunting for a .clap file.