### PR TITLE
Add syntax highlighting and collapsing with fountain format for script editor

### DIFF
--- a/src/components/editors/ScriptEditor/index.tsx
+++ b/src/components/editors/ScriptEditor/index.tsx
@@ -1,72 +1,78 @@
-"use client"
-import { TimelineStore, useTimeline } from "@aitube/timeline"
-import Editor, { Monaco, OnMount } from "@monaco-editor/react"
-import * as MonacoEditor from "monaco-editor"
-import { useEffect, useRef } from "react"
+"use client";
+import { TimelineStore, useTimeline } from "@aitube/timeline";
+import Editor, { Monaco, OnMount } from "@monaco-editor/react";
+import * as MonacoEditor from "monaco-editor";
+import { useEffect, useRef } from "react";
 
-import { useScriptEditor } from "@/services/editors/script-editor/useScriptEditor"
-import { useUI } from "@/services/ui"
-import { themes } from "@/services/ui/theme"
+import { useScriptEditor } from "@/services/editors/script-editor/useScriptEditor";
+import { useUI } from "@/services/ui";
+import { themes } from "@/services/ui/theme";
 
-import "./styles.css"
+import "./styles.css";
 
-export const fountainLanguageId = 'fountain';
+export const fountainLanguageId = "fountain";
 
 export function ScriptEditor() {
-  const standaloneCodeEditor = useScriptEditor(s => s.standaloneCodeEditor)
-  const setStandaloneCodeEditor = useScriptEditor(s => s.setStandaloneCodeEditor)
-  const draft = useScriptEditor(s => s.draft)
-  const setDraft = useScriptEditor(s => s.setDraft)
-  const loadDraftFromClap = useScriptEditor(s => s.loadDraftFromClap)
-  const onDidScrollChange = useScriptEditor(s => s.onDidScrollChange)
-  const jumpCursorOnLineClick = useScriptEditor(s => s.jumpCursorOnLineClick)
+  const standaloneCodeEditor = useScriptEditor((s) => s.standaloneCodeEditor);
+  const setStandaloneCodeEditor = useScriptEditor(
+    (s) => s.setStandaloneCodeEditor,
+  );
+  const draft = useScriptEditor((s) => s.draft);
+  const setDraft = useScriptEditor((s) => s.setDraft);
+  const loadDraftFromClap = useScriptEditor((s) => s.loadDraftFromClap);
+  const onDidScrollChange = useScriptEditor((s) => s.onDidScrollChange);
+  const jumpCursorOnLineClick = useScriptEditor((s) => s.jumpCursorOnLineClick);
 
-  const clap = useTimeline((s: TimelineStore) => s.clap)
+  const clap = useTimeline((s: TimelineStore) => s.clap);
 
-  const editorRef = useRef<MonacoEditor.editor.IStandaloneCodeEditor | null>(null);
+  const editorRef = useRef<MonacoEditor.editor.IStandaloneCodeEditor | null>(
+    null,
+  );
   const monacoRef = useRef<Monaco | null>(null);
 
   useEffect(() => {
     if (clap && clap.meta.screenplay) {
-      loadDraftFromClap(clap)
+      loadDraftFromClap(clap);
     }
-  }, [clap, loadDraftFromClap])
+  }, [clap, loadDraftFromClap]);
 
   const onMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
     monacoRef.current = monaco;
-    setStandaloneCodeEditor(editor)
+    setStandaloneCodeEditor(editor);
 
     editor.onMouseDown((e) => {
       const position = editor.getPosition();
       if (position) {
-        jumpCursorOnLineClick(position.lineNumber)
+        jumpCursorOnLineClick(position.lineNumber);
       }
-    })
+    });
 
-    editor.onDidScrollChange(({ scrollTop, scrollLeft, scrollWidth, scrollHeight }) => {
-      onDidScrollChange({ scrollTop, scrollLeft, scrollWidth, scrollHeight })
-    })
+    editor.onDidScrollChange(
+      ({ scrollTop, scrollLeft, scrollWidth, scrollHeight }) => {
+        onDidScrollChange({ scrollTop, scrollLeft, scrollWidth, scrollHeight });
+      },
+    );
 
     editor.onDidChangeModelContent(() => {
-      const updatedDraft = editor.getValue()
-      setDraft(updatedDraft)
-    })
+      const updatedDraft = editor.getValue();
+      setDraft(updatedDraft);
+    });
 
     // Apply the theme and update the editor
     monaco.editor.setTheme(themeName);
     editor.updateOptions({
       fontSize: editorFontSize,
       folding: true,
-      foldingStrategy: 'auto',
+      foldingStrategy: "auto",
       foldingHighlight: true,
-      showFoldingControls: 'always',
+      showFoldingControls: "always",
     });
 
     applyCollapsibleRanges(editor, monaco);
     editor.onDidChangeModelContent(() => {
       applyCollapsibleRanges(editor, monaco);
-    })
+    });
 
     // Force a re-render of the editor and trigger syntax highlighting
     setTimeout(() => {
@@ -80,14 +86,17 @@ export function ScriptEditor() {
         model.tokenization.forceTokenization(fullRange.endLineNumber);
       }
     }, 50);
-  }
+  };
 
-  const applyCollapsibleRanges = (editor: MonacoEditor.editor.IStandaloneCodeEditor, monaco: Monaco) => {
+  const applyCollapsibleRanges = (
+    editor: MonacoEditor.editor.IStandaloneCodeEditor,
+    monaco: Monaco,
+  ) => {
     const model = editor.getModel();
     if (!model) return;
 
     const text = model.getValue();
-    const lines = text.split('\n');
+    const lines = text.split("\n");
     const foldingRanges: MonacoEditor.languages.FoldingRange[] = [];
 
     let sceneStart = -1;
@@ -102,7 +111,7 @@ export function ScriptEditor() {
           foldingRanges.push({
             start: sceneStart + 1,
             end: i,
-            kind: monaco.languages.FoldingRangeKind.Region
+            kind: monaco.languages.FoldingRangeKind.Region,
           });
         }
         sceneStart = i;
@@ -113,18 +122,18 @@ export function ScriptEditor() {
           foldingRanges.push({
             start: characterStart + 1,
             end: i,
-            kind: monaco.languages.FoldingRangeKind.Region
+            kind: monaco.languages.FoldingRangeKind.Region,
           });
         }
         characterStart = i;
       }
       // End of dialogue block or scene description
-      else if (line === '') {
+      else if (line === "") {
         if (characterStart !== -1) {
           foldingRanges.push({
             start: characterStart + 1,
             end: i,
-            kind: monaco.languages.FoldingRangeKind.Region
+            kind: monaco.languages.FoldingRangeKind.Region,
           });
           characterStart = -1;
         }
@@ -136,112 +145,120 @@ export function ScriptEditor() {
       foldingRanges.push({
         start: sceneStart + 1,
         end: lines.length,
-        kind: monaco.languages.FoldingRangeKind.Region
+        kind: monaco.languages.FoldingRangeKind.Region,
       });
     }
     if (characterStart !== -1) {
       foldingRanges.push({
         start: characterStart + 1,
         end: lines.length,
-        kind: monaco.languages.FoldingRangeKind.Region
+        kind: monaco.languages.FoldingRangeKind.Region,
       });
     }
 
     monaco.languages.registerFoldingRangeProvider(fountainLanguageId, {
-      provideFoldingRanges: () => foldingRanges
+      provideFoldingRanges: () => foldingRanges,
     });
-  }
+  };
 
-  const setMonaco = useScriptEditor(s => s.setMonaco)
-  const setTextModel = useScriptEditor(s => s.setTextModel)
-  const setMouseIsInside = useScriptEditor(s => s.setMouseIsInside)
-  const themeName = useUI(s => s.themeName)
-  const editorFontSize = useUI(s => s.editorFontSize)
+  const setMonaco = useScriptEditor((s) => s.setMonaco);
+  const setTextModel = useScriptEditor((s) => s.setTextModel);
+  const setMouseIsInside = useScriptEditor((s) => s.setMouseIsInside);
+  const themeName = useUI((s) => s.themeName);
+  const editorFontSize = useUI((s) => s.editorFontSize);
 
   const beforeMount = async (monaco: Monaco) => {
-    setMonaco(monaco)
+    setMonaco(monaco);
 
     function registerFountainLanguage(monaco: Monaco) {
       const fountainTokenProvider: MonacoEditor.languages.IMonarchLanguage = {
-        defaultToken: '',
-        tokenPostfix: '.fountain',
+        defaultToken: "",
+        tokenPostfix: ".fountain",
 
         tokenizer: {
           root: [
-            [/^#.*$/, 'comment'],
-            [/^(INT|EXT|EST|INT\.\/EXT\.)\s*.*$/, 'sceneHeading'],
-            [/^[A-Z][A-Z0-9\s]*(\(.*\))?$/, 'character'],
-            [/^\(.*\)$/, 'parenthetical'],
-            [/^>.*$/, 'transition'],
-            [/^\[\[.*\]\]$/, 'note'],
-            [/^===.*$/, 'pageBreak'],
-            [/^=.*$/, 'synopsisSeparator'],
-            [/^\..*$/, 'sceneNumber'],
-            [/^\*.*$/, 'emphasis'],
-            [/^_.*_$/, 'underline'],
-            [/^\s*$/, 'emptyLine'],
-            [/^[^A-Z\n]+$/, 'dialogue'],
-            [/^.*$/, 'action']
-          ]
-        }
+            [/^#.*$/, "comment"],
+            [/^(INT|EXT|EST|INT\.\/EXT\.)\s*.*$/, "sceneHeading"],
+            [/^[A-Z][A-Z0-9\s]*(\(.*\))?$/, "character"],
+            [/^\(.*\)$/, "parenthetical"],
+            [/^>.*$/, "transition"],
+            [/^\[\[.*\]\]$/, "note"],
+            [/^===.*$/, "pageBreak"],
+            [/^=.*$/, "synopsisSeparator"],
+            [/^\..*$/, "sceneNumber"],
+            [/^\*.*$/, "emphasis"],
+            [/^_.*_$/, "underline"],
+            [/^\s*$/, "emptyLine"],
+            [/^[^A-Z\n]+$/, "dialogue"],
+            [/^.*$/, "action"],
+          ],
+        },
       };
       monaco.languages.register({ id: fountainLanguageId });
-      monaco.languages.setMonarchTokensProvider(fountainLanguageId, fountainTokenProvider);
+      monaco.languages.setMonarchTokensProvider(
+        fountainLanguageId,
+        fountainTokenProvider,
+      );
     }
 
-    registerFountainLanguage(monaco)
+    registerFountainLanguage(monaco);
 
     for (const theme of Object.values(themes)) {
       monaco.editor.defineTheme(theme.id, {
-        base: 'vs-dark',
+        base: "vs-dark",
         inherit: true,
         rules: [
-          { token: '', foreground: theme.editorTextColor || theme.defaultTextColor || "" },
-          { token: 'comment', foreground: '#6A9955' },
-          { token: 'sceneHeading', foreground: '#4EC9B0', fontWeight: 'bold' },
-          { token: 'character', foreground: '#DCDCAA', fontWeight: 'bold' },
-          { token: 'parenthetical', foreground: '#9CDCFE' },
-          { token: 'dialogue', foreground: '#D4D4D4' },
-          { token: 'transition', foreground: '#CE9178', fontStyle: 'italic' },
-          { token: 'note', foreground: '#6796E6' },
-          { token: 'pageBreak', foreground: '#D16969' },
-          { token: 'synopsisSeparator', foreground: '#608B4E' },
-          { token: 'sceneNumber', foreground: '#B5CEA8' },
-          { token: 'emphasis', foreground: '#D4D4D4', fontStyle: 'italic' },
-          { token: 'underline', foreground: '#D4D4D4', fontStyle: 'underline' },
-          { token: 'action', foreground: '#D4D4D4' },
+          {
+            token: "",
+            foreground: theme.editorTextColor || theme.defaultTextColor || "",
+          },
+          { token: "comment", foreground: "#6A9955" },
+          { token: "sceneHeading", foreground: "#4EC9B0", fontWeight: "bold" },
+          { token: "character", foreground: "#DCDCAA", fontWeight: "bold" },
+          { token: "parenthetical", foreground: "#9CDCFE" },
+          { token: "dialogue", foreground: "#D4D4D4" },
+          { token: "transition", foreground: "#CE9178", fontStyle: "italic" },
+          { token: "note", foreground: "#6796E6" },
+          { token: "pageBreak", foreground: "#D16969" },
+          { token: "synopsisSeparator", foreground: "#608B4E" },
+          { token: "sceneNumber", foreground: "#B5CEA8" },
+          { token: "emphasis", foreground: "#D4D4D4", fontStyle: "italic" },
+          { token: "underline", foreground: "#D4D4D4", fontStyle: "underline" },
+          { token: "action", foreground: "#D4D4D4" },
         ],
         colors: {
-          'editor.background': theme.editorBgColor || theme.defaultBgColor || '#000000',
-          'editorCursor.foreground': theme.editorCursorColor || theme.defaultPrimaryColor || "",
-          'editor.lineHighlightBackground': '#44403c',
-          'editorLineNumber.foreground': '#78716c',
-          'editor.selectionBackground': '#44403c',
-          'editorIndentGuide.background': '#78716c',
-          'editorIndentGuide.activeBackground': '#a8a29e',
-          'editorWhitespace.foreground': '#a8a29e',
+          "editor.background":
+            theme.editorBgColor || theme.defaultBgColor || "#000000",
+          "editorCursor.foreground":
+            theme.editorCursorColor || theme.defaultPrimaryColor || "",
+          "editor.lineHighlightBackground": "#44403c",
+          "editorLineNumber.foreground": "#78716c",
+          "editor.selectionBackground": "#44403c",
+          "editorIndentGuide.background": "#78716c",
+          "editorIndentGuide.activeBackground": "#a8a29e",
+          "editorWhitespace.foreground": "#a8a29e",
         },
-      })
+      });
     }
 
-    monaco.editor.setTheme(themes.backstage.id)
+    monaco.editor.setTheme(themes.backstage.id);
 
     const textModel: MonacoEditor.editor.ITextModel = monaco.editor.createModel(
       draft,
-      fountainLanguageId
-    )
-    setTextModel(textModel)
-  }
+      fountainLanguageId,
+    );
+    setTextModel(textModel);
+  };
 
   const handleCollapseAll = () => {
     if (!editorRef.current) return;
-    editorRef.current.trigger('fold', 'editor.foldAll', null);
-  }
+    editorRef.current.trigger("fold", "editor.foldAll", null);
+  };
 
   const handleExpandAll = () => {
     if (!editorRef.current) return;
-    editorRef.current.trigger('unfold', 'editor.unfoldAll', null);
-  }
+    editorRef.current.trigger("unfold", "editor.unfoldAll", null);
+  };
 
   return (
     <div
@@ -250,8 +267,12 @@ export function ScriptEditor() {
       onMouseLeave={() => setMouseIsInside(false)}
     >
       <div className="flex justify-end mb-2">
-        <button onClick={handleCollapseAll} className="m-1 text-xs">Collapse All</button>
-        <button onClick={handleExpandAll} className="m-1 text-xs">Expand All</button>
+        <button onClick={handleCollapseAll} className="m-1 text-xs">
+          Collapse All
+        </button>
+        <button onClick={handleExpandAll} className="m-1 text-xs">
+          Expand All
+        </button>
       </div>
       <Editor
         height="100%"
@@ -262,16 +283,16 @@ export function ScriptEditor() {
         options={{
           fontSize: editorFontSize,
           folding: true,
-          foldingStrategy: 'auto',
+          foldingStrategy: "auto",
           automaticLayout: true,
           scrollBeyondLastLine: false,
           minimap: { enabled: false },
-          lineNumbers: 'off',
+          lineNumbers: "off",
           glyphMargin: true,
           fixedOverflowWidgets: true,
         }}
         language={fountainLanguageId}
       />
     </div>
-  )
+  );
 }

--- a/src/services/editors/script-editor/useScriptEditor.ts
+++ b/src/services/editors/script-editor/useScriptEditor.ts
@@ -1,41 +1,62 @@
-"use client"
+"use client";
 
-import { create } from "zustand"
-import { Monaco } from "@monaco-editor/react"
-import MonacoEditor from "monaco-editor"
-import { ClapProject, ClapSegmentCategory } from "@aitube/clap"
-import { TimelineStore, useTimeline, leftBarTrackScaleWidth } from "@aitube/timeline"
-import { ScriptEditorStore, EditorView, ScrollData } from "@aitube/clapper-services"
+import { create } from "zustand";
+import { Monaco } from "@monaco-editor/react";
+import MonacoEditor from "monaco-editor";
+import { ClapProject, ClapSegmentCategory } from "@aitube/clap";
+import {
+  TimelineStore,
+  useTimeline,
+  leftBarTrackScaleWidth,
+} from "@aitube/timeline";
+import {
+  ScriptEditorStore,
+  EditorView,
+  ScrollData,
+} from "@aitube/clapper-services";
 
-import { getDefaultScriptEditorState } from "./getDefaultScriptEditorState"
+import { getDefaultScriptEditorState } from "./getDefaultScriptEditorState";
 
 export const useScriptEditor = create<ScriptEditorStore>((set, get) => ({
   ...getDefaultScriptEditorState(),
-  setMonaco: (monaco?: Monaco) => { set({ monaco }) },
-  setTextModel: (textModel?: MonacoEditor.editor.ITextModel) => { set({ textModel }) },
-  setStandaloneCodeEditor: (standaloneCodeEditor?: MonacoEditor.editor.IStandaloneCodeEditor) => { set({ standaloneCodeEditor }) },
-  setMouseIsInside: (mouseIsInside: boolean) => { set({ mouseIsInside }) },
+  setMonaco: (monaco?: Monaco) => {
+    set({ monaco });
+  },
+  setTextModel: (textModel?: MonacoEditor.editor.ITextModel) => {
+    set({ textModel });
+  },
+  setStandaloneCodeEditor: (
+    standaloneCodeEditor?: MonacoEditor.editor.IStandaloneCodeEditor,
+  ) => {
+    set({ standaloneCodeEditor });
+  },
+  setMouseIsInside: (mouseIsInside: boolean) => {
+    set({ mouseIsInside });
+  },
   loadDraftFromClap: (clap: ClapProject) => {
-    const { setDraft } = get()
+    const { setDraft } = get();
 
-    setDraft(clap.meta.screenplay)
+    setDraft(clap.meta.screenplay);
   },
   setDraft: (draft: string) => {
-    const { draft: previousDraft, highlightElements, textModel } = get()
-    if (draft === previousDraft) { return }
-    set({ draft })
+    const { draft: previousDraft, highlightElements, textModel } = get();
+    if (draft === previousDraft) {
+      return;
+    }
+    set({ draft });
 
-    
-    if (!textModel) { return }
+    if (!textModel) {
+      return;
+    }
     // we need to update the model
-    textModel?.setValue(draft)
+    textModel?.setValue(draft);
 
     // and highlight the text again
-    highlightElements()
+    highlightElements();
   },
   publishDraftToTimeline: async (): Promise<void> => {
-    const { draft } = get()
-    console.log(`user asked to update the whole scene! this is expensive..`)
+    const { draft } = get();
+    console.log(`user asked to update the whole scene! this is expensive..`);
     // we can do something smart, which is to only reconstruct the impacted segments
     // and shift the rest along the time axis, without modifying it
   },
@@ -43,15 +64,15 @@ export const useScriptEditor = create<ScriptEditorStore>((set, get) => ({
     scrollHeight,
     scrollLeft,
     scrollTop,
-    scrollWidth
+    scrollWidth,
   }: ScrollData) => {
-    const { 
+    const {
       scrollHeight: previousScrollHeight,
       scrollLeft: previousScrollLeft,
       scrollTop: previousScrollTop,
       scrollWidth: previousScrollWidth,
-      mouseIsInside
-    } = get()
+      mouseIsInside,
+    } = get();
 
     // skip if nothing changed
     if (
@@ -60,7 +81,7 @@ export const useScriptEditor = create<ScriptEditorStore>((set, get) => ({
       scrollTop === previousScrollTop &&
       scrollWidth === previousScrollWidth
     ) {
-      return
+      return;
     }
 
     set({
@@ -68,20 +89,23 @@ export const useScriptEditor = create<ScriptEditorStore>((set, get) => ({
       scrollLeft,
       scrollTop,
       scrollWidth,
-    })
+    });
 
     // if the scroll event happened while we where inside the editor,
     // then we need to dispatch the it
     if (mouseIsInside) {
+      const timeline: TimelineStore = useTimeline.getState();
+      if (!timeline.timelineCamera || !timeline.timelineControls) {
+        return;
+      }
 
-      const timeline: TimelineStore = useTimeline.getState()
-      if (!timeline.timelineCamera || !timeline.timelineControls) { return }
+      const { standaloneCodeEditor } = get();
 
-      const { standaloneCodeEditor } = get()
-    
-      const scrollRatio = scrollTop / scrollHeight
-      const scrollX = Math.round(leftBarTrackScaleWidth + scrollRatio * timeline.contentWidth)
-      
+      const scrollRatio = scrollTop / scrollHeight;
+      const scrollX = Math.round(
+        leftBarTrackScaleWidth + scrollRatio * timeline.contentWidth,
+      );
+
       /*console.log({
         scrollHeight,
         scrollLeft,
@@ -93,79 +117,88 @@ export const useScriptEditor = create<ScriptEditorStore>((set, get) => ({
        */
 
       if (useTimeline.getState().scrolX !== scrollX) {
-        useTimeline.setState({ scrollX })
-        timeline.timelineCamera.position.setX(scrollX)
-        timeline.timelineControls.target.setX(scrollX)
+        useTimeline.setState({ scrollX });
+        timeline.timelineCamera.position.setX(scrollX);
+        timeline.timelineControls.target.setX(scrollX);
       }
     }
   },
   jumpCursorOnLineClick: (line?: number) => {
-    if (typeof line !== "number") { return }
-    const timeline: TimelineStore = useTimeline.getState()
-  
-    const { lineNumberToMentionedSegments } = timeline
+    if (typeof line !== "number") {
+      return;
+    }
+    const timeline: TimelineStore = useTimeline.getState();
 
-    const mentionedSegments = lineNumberToMentionedSegments[line] || []
+    const { lineNumberToMentionedSegments } = timeline;
 
-    const firstMentionedSegment = mentionedSegments.at(0)
+    const mentionedSegments = lineNumberToMentionedSegments[line] || [];
 
+    const firstMentionedSegment = mentionedSegments.at(0);
 
-    if (typeof firstMentionedSegment?.startTimeInMs !== "number") { return }
+    if (typeof firstMentionedSegment?.startTimeInMs !== "number") {
+      return;
+    }
 
-    const { startTimeInMs } = firstMentionedSegment
+    const { startTimeInMs } = firstMentionedSegment;
 
-    timeline.setCursorTimestampAtInMs(startTimeInMs)
+    timeline.setCursorTimestampAtInMs(startTimeInMs);
   },
 
   highlightElements: () => {
-    const timeline: TimelineStore = useTimeline.getState()
-    const { clap } = timeline
-    
-    const { textModel, standaloneCodeEditor, applyClassNameToKeywords } = get()
-    if (!textModel || !standaloneCodeEditor || !clap) { return }
+    const timeline: TimelineStore = useTimeline.getState();
+    const { clap } = timeline;
 
-    const characters = clap.entities.filter(entity => entity.category === ClapSegmentCategory.CHARACTER).map(entity => entity.triggerName)
+    const { textModel, standaloneCodeEditor, applyClassNameToKeywords } = get();
+    if (!textModel || !standaloneCodeEditor || !clap) {
+      return;
+    }
+
+    const characters = clap.entities
+      .filter((entity) => entity.category === ClapSegmentCategory.CHARACTER)
+      .map((entity) => entity.triggerName);
 
     // any character
-    applyClassNameToKeywords(
-      "entity entity-character",
-      characters
-    )
+    applyClassNameToKeywords("entity entity-character", characters);
 
     // UPPERCASE CHARACTER
     applyClassNameToKeywords(
       "entity entity-character entity-highlight",
       characters,
-      true
-    )
+      true,
+    );
 
-    const locations = clap.entities.filter(entity => entity.category === ClapSegmentCategory.LOCATION).map(entity => entity.triggerName)
-    // any location 
-    applyClassNameToKeywords(
-      "entity entity-location",
-      locations
-    )
+    const locations = clap.entities
+      .filter((entity) => entity.category === ClapSegmentCategory.LOCATION)
+      .map((entity) => entity.triggerName);
+    // any location
+    applyClassNameToKeywords("entity entity-location", locations);
 
     // UPPERCASE LOCATION
     applyClassNameToKeywords(
       "entity entity-location entity-highlight",
       locations,
-      true
-    )
+      true,
+    );
   },
-  applyClassNameToKeywords: (className: string = "", keywords: string[] = [], caseSensitive = false) => {
-    const timeline: TimelineStore = useTimeline.getState()
-    const { clap } = timeline
-    
-    const { textModel, standaloneCodeEditor } = get()
-    if (!textModel || !standaloneCodeEditor || !clap) { return }
+  applyClassNameToKeywords: (
+    className: string = "",
+    keywords: string[] = [],
+    caseSensitive = false,
+  ) => {
+    const timeline: TimelineStore = useTimeline.getState();
+    const { clap } = timeline;
+
+    const { textModel, standaloneCodeEditor } = get();
+    if (!textModel || !standaloneCodeEditor || !clap) {
+      return;
+    }
 
     keywords.forEach((entityTriggerName: string): void => {
       const matches: MonacoEditor.editor.FindMatch[] = textModel.findMatches(
         // searchString — The string used to search. If it is a regular expression, set isRegex to true.
         // searchString: string,
         entityTriggerName,
-        
+
         // @param searchOnlyEditableRange — Limit the searching to only search inside the editable range of the model.
         // searchOnlyEditableRange: boolean,
         false,
@@ -173,7 +206,7 @@ export const useScriptEditor = create<ScriptEditorStore>((set, get) => ({
         // / @param isRegex — Used to indicate that searchString is a regular expression.
         // isRegex: boolean,
         false,
-    
+
         // @param matchCase — Force the matching to match lower/upper case exactly.
         // matchCase: boolean,
         caseSensitive,
@@ -188,7 +221,7 @@ export const useScriptEditor = create<ScriptEditorStore>((set, get) => ({
 
         // limitResultCount — Limit the number of results
         // limitResultCount?: number
-      )
+      );
 
       matches.forEach((match: MonacoEditor.editor.FindMatch): void => {
         standaloneCodeEditor.createDecorationsCollection([
@@ -196,19 +229,20 @@ export const useScriptEditor = create<ScriptEditorStore>((set, get) => ({
             range: match.range,
             options: {
               isWholeLine: false,
-              inlineClassName: className
-            }
+              inlineClassName: className,
+            },
           },
-        ])
-      })
-    })
+        ]);
+      });
+    });
   },
-  setCurrent: (current?: string) => { set({ current }) },
+  setCurrent: (current?: string) => {
+    set({ current });
+  },
   undo: () => {},
   redo: () => {},
-}))
-
+}));
 
 if (typeof window !== "undefined") {
-  (window as any).useScriptEditor = useScriptEditor
+  (window as any).useScriptEditor = useScriptEditor;
 }


### PR DESCRIPTION
This PR adds syntax highlighting and collapsing / expanding for the fountain format to the script editor.

Solves some but not all of these: https://github.com/jbilcke-hf/clapper/issues/14

I couldn't find anything for fountain and monaco. There is the betterfountain project for vscode, which probably has really nice detailed advanced features. but this solution is relatively simple and seems to get the job done for my test script.

I tried undo/redo buttons and didn't like them. key commands with ctrl z // cmd z work.


<img width="627" alt="Screenshot 2024-07-11 at 10 37 36 PM" src="https://github.com/user-attachments/assets/83a57bea-6a0e-4b4a-b488-23652de4da6c">
<img width="596" alt="Screenshot 2024-07-11 at 10 36 51 PM" src="https://github.com/user-attachments/assets/1964a2e1-20f8-4b44-b697-f924b9d62a85">
