### PR TITLE
fix: use binary encoding before creating buffer in base64DataUriToBlob

### DIFF
--- a/src/lib/utils/base64DataUriToBlob.ts
+++ b/src/lib/utils/base64DataUriToBlob.ts
@@ -3,7 +3,7 @@ export function base64DataUriToBlob(dataURI: string) {
 
   const match = dataURI.match(/(?:image|video|audio|text)\/[^;]+/)
   const type = match?.[0] || ""
-  const base64 = dataURI.replace(/^[^,]+,/, '');
+  const base64 = Buffer.from(dataURI.replace(/^[^,]+,/, ''), 'base64').toString('binary');
   const arrayBuffer = new ArrayBuffer(base64.length);
   const typedArray = new Uint8Array(arrayBuffer);
 


### PR DESCRIPTION
Hi,

When dealing with a fetch with FormData, I wanted to reuse `base64DataUriToBlob` to convert an data-uri image to Blob but the result was corrupted, this change will fix it.

Thanks!