### PR TITLE
fix: screenplay not loaded when importing txt or clap

### DIFF
--- a/public/images/providers/comfyui.png
+++ b/public/images/providers/comfyui.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ede11b7153e088595273c719e91f29656498ca26d3370505d7ec1e21436fdf9
+size 2234

--- a/src/app/api/resolve/providers/comfyui/index.ts
+++ b/src/app/api/resolve/providers/comfyui/index.ts
@@ -28,7 +28,7 @@ export async function resolveSegment(
   // for API doc please see:
   // https://github.com/tctien342/comfyui-sdk/blob/main/examples/example-t2i.ts
   const api = new ComfyApi(
-    request.settings.comfyUiApiUrl || 'http://localhost:8189'
+    request.settings.comfyUiApiUrl || 'http://localhost:8188'
   ).init()
 
   if (request.segment.category === ClapSegmentCategory.STORYBOARD) {

--- a/src/components/core/providers/logos.ts
+++ b/src/components/core/providers/logos.ts
@@ -2,7 +2,7 @@ import { ClapWorkflowProvider } from '@aitube/clap'
 
 const none = '/images/providers/none.png'
 const builtin = '/images/providers/none.png' // <-- TODO put Clapper logo here
-const comfyui = '/images/providers/none.png' // <-- TODO put ComfyUI logo here
+const comfyui = '/images/providers/comfyui.png'
 const anthropic = '/images/providers/anthropic.png'
 const cohere = '/images/providers/cohere.png'
 const comfyicu = '/images/providers/comfyicu.png'

--- a/src/components/settings/provider.tsx
+++ b/src/components/settings/provider.tsx
@@ -123,7 +123,7 @@ export function SettingsSectionProvider() {
           label="ComfyUI API URL"
           value={comfyUiApiUrl}
           defaultValue={defaultSettings.comfyUiApiUrl}
-          onChange={setComfyIcuApiKey}
+          onChange={setComfyUiApiUrl}
           type="text"
         />
 
@@ -132,7 +132,7 @@ export function SettingsSectionProvider() {
           value={comfyUiClientId}
           defaultValue={defaultSettings.comfyUiClientId}
           onChange={setComfyUiClientId}
-          type={apiKeyType}
+          type="text"
         />
 
         <FormInput

--- a/src/services/settings/getDefaultSettingsState.ts
+++ b/src/services/settings/getDefaultSettingsState.ts
@@ -76,7 +76,7 @@ export function getDefaultSettingsState(): SettingsState {
     comfyWorkflowForSound: '{}',
     comfyWorkflowForMusic: '{}',
 
-    comfyUiApiUrl: 'http://localhost:8189',
+    comfyUiApiUrl: 'http://localhost:8188',
 
     // those are not designed for Hugging Face specifically,
     // but to be compatible with any Gradio API URL that the


### PR DESCRIPTION
Hi,

The `useEffect` with `getClap` was not detecting changes, refactoring it to use `meta` is a simple fix but I think a better approach is to fill the proper store when setting `timeline.setClap()` to avoid complications with `useEffect` apart of avoiding additional renders. An even better approach could be to have a global store where to proxy calls to `TimelineStore` and `ScriptEditorStore` via a unique `setClap`, I think we could do that in the future.