### PR TITLE
fix: improve text visibility in light mode

### DIFF
--- a/packages/app/src/components/dialogs/loader/LoadingDialog.tsx
+++ b/packages/app/src/components/dialogs/loader/LoadingDialog.tsx
@@ -35,7 +35,9 @@ export function LoadingDialog({ className = '' }: { className?: string }) {
             }
           )}
         >
-          <div className={cn(`text-lg`, className)}>{currentMessage}</div>
+          <div className={cn(`text-lg text-neutral-200`, className)}>
+            {currentMessage}
+          </div>
           <div className="flex w-full flex-col items-center justify-center p-8">
             <Progress value={progress} className="w-full" />
           </div>

--- a/packages/app/src/components/settings/assistant.tsx
+++ b/packages/app/src/components/settings/assistant.tsx
@@ -4,8 +4,12 @@ export function SettingsSectionAssistant() {
   return (
     <div className="flex flex-col justify-between space-y-6">
       <FormSection label="AI Assistant">
-        <p>No settings for the AI assistant yet.</p>
-        <p>(in the future we might add a system prompt here)</p>
+        <p className="text-neutral-200">
+          No settings for the AI assistant yet.
+        </p>
+        <p className="text-neutral-200">
+          (in the future we might add a system prompt here)
+        </p>
       </FormSection>
     </div>
   )


### PR DESCRIPTION
- Add text-neutral-200 class to LoadingDialog messages
- Add text-neutral-200 class to Assistant settings text

This ensures better text contrast and readability when using light mode theme.