### PR TITLE
Add timeline track and clip authoring

### DIFF
--- a/packages/timeline/src/ClapTimeline.tsx
+++ b/packages/timeline/src/ClapTimeline.tsx
@@ -21,6 +21,7 @@ import { TimelineCamera } from "./components/camera"
 import { useTimeline } from "./hooks"
 import { topBarTimeScaleHeight } from "./constants/themes"
 import { TimelineStore } from "./types"
+import { TimelineAuthoringToolbar } from "./components/timeline/TimelineAuthoringToolbar"
 
 export function ClapTimeline({
   clap,
@@ -112,8 +113,10 @@ export function ClapTimeline({
     <div
       className={cn(`w-full h-full`, className)}
       style={{
+        position: "relative",
         backgroundColor: theme.grid.backgroundColor
       }}>
+      <TimelineAuthoringToolbar />
       <AutoSizer style={{
         height: "100%", // <-- mandatory otherwise the timeline won't show up
         width: "100%" // <-- mandatory otherwise the horizontal scroller won't show up

--- a/packages/timeline/src/components/timeline/TimelineAuthoringToolbar.tsx
+++ b/packages/timeline/src/components/timeline/TimelineAuthoringToolbar.tsx
@@ -1,0 +1,114 @@
+import { ClapSegmentCategory } from "@aitube/clap"
+import type { CSSProperties } from "react"
+
+import { useTimeline } from "@/hooks"
+import { TIMELINE_AUTHORING_CATEGORIES, getTrackCategory } from "@/utils/timelineAuthoring"
+
+const toolbarStyle: CSSProperties = {
+  position: "absolute",
+  left: 12,
+  top: 10,
+  zIndex: 10,
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "8px 10px",
+  borderRadius: 6,
+  background: "rgba(17, 24, 39, 0.88)",
+  color: "white",
+  boxShadow: "0 8px 24px rgba(0, 0, 0, 0.22)",
+  fontSize: 12,
+}
+
+const controlStyle: CSSProperties = {
+  height: 28,
+  border: "1px solid rgba(255, 255, 255, 0.18)",
+  borderRadius: 4,
+  background: "rgba(255, 255, 255, 0.08)",
+  color: "white",
+  padding: "0 8px",
+}
+
+const buttonStyle: CSSProperties = {
+  ...controlStyle,
+  cursor: "pointer",
+  fontWeight: 600,
+}
+
+export function TimelineAuthoringToolbar() {
+  const tracks = useTimeline(state => state.tracks)
+  const selectedTrackId = useTimeline(state => state.selectedTrackId)
+  const selectedTrackCategory = useTimeline(state => state.selectedTrackCategory)
+  const setSelectedTrack = useTimeline(state => state.setSelectedTrack)
+  const setSelectedTrackCategory = useTimeline(state => state.setSelectedTrackCategory)
+  const setTrackCategory = useTimeline(state => state.setTrackCategory)
+  const createTrack = useTimeline(state => state.createTrack)
+  const createClipOnTrack = useTimeline(state => state.createClipOnTrack)
+
+  const selectedTrack = typeof selectedTrackId === "number" ? tracks[selectedTrackId] : undefined
+  const selectedTrackCategoryFromTrack = getTrackCategory(selectedTrack)
+  const activeCategory = selectedTrackCategoryFromTrack || selectedTrackCategory
+  const selectedTrackCanChangeCategory = Boolean(selectedTrack) && !selectedTrack?.occupied
+
+  const handleCategoryChange = (value: string) => {
+    const category = value as ClapSegmentCategory
+    if (typeof selectedTrackId !== "number") {
+      setSelectedTrackCategory(category)
+      return
+    }
+
+    if (setTrackCategory(selectedTrackId, category)) {
+      setSelectedTrackCategory(category)
+    }
+  }
+
+  return (
+    <div style={toolbarStyle}>
+      <select
+        aria-label="Track"
+        value={selectedTrackId ?? ""}
+        onChange={event => setSelectedTrack(event.target.value === "" ? undefined : Number(event.target.value))}
+        style={{ ...controlStyle, minWidth: 110 }}
+      >
+        <option value="">Track</option>
+        {tracks.map(track => (
+          <option key={track.id} value={track.id}>
+            {`Track ${track.id}`}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label="Clip type"
+        value={activeCategory}
+        onChange={event => handleCategoryChange(event.target.value)}
+        disabled={Boolean(selectedTrack) && !selectedTrackCanChangeCategory}
+        style={{ ...controlStyle, minWidth: 110 }}
+      >
+        {TIMELINE_AUTHORING_CATEGORIES.map(category => (
+          <option key={category} value={category}>
+            {category}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        style={buttonStyle}
+        onClick={() => createTrack(activeCategory)}
+      >
+        + Track
+      </button>
+      <button
+        type="button"
+        style={buttonStyle}
+        onClick={() => {
+          void createClipOnTrack({
+            trackId: selectedTrackId,
+            category: activeCategory,
+          })
+        }}
+      >
+        + Clip
+      </button>
+    </div>
+  )
+}

--- a/packages/timeline/src/hooks/useTimeline.ts
+++ b/packages/timeline/src/hooks/useTimeline.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand"
 import * as THREE from "three"
 import type { ThreeEvent } from "@react-three/fiber"
-import { ClapProject, ClapSegment, ClapSegmentCategory, isValidNumber, newClap, serializeClap, ClapTracks, ClapEntity, ClapMeta } from "@aitube/clap"
+import { ClapAssetSource, ClapProject, ClapSegment, ClapSegmentCategory, ClapSegmentStatus, isValidNumber, newClap, serializeClap, ClapTracks, ClapEntity, ClapMeta } from "@aitube/clap"
 
 import { TimelineSegment, SegmentEditionStatus, SegmentVisibility, TimelineStore, SegmentArea, SegmentPointerEvent, SegmentEventCallbackHandler, Invalidate } from "@/types/timeline"
 import { getDefaultProjectState, getDefaultState } from "@/utils/getDefaultState"
@@ -13,6 +13,15 @@ import { TimelineCameraImpl } from "@/components/camera/types"
 import { IsPlaying, JumpAt, TimelineCursorImpl, TogglePlayback } from "@/components/timeline/types"
 import { computeContentSizeMetrics } from "@/compute/computeContentSizeMetrics"
 import { topBarTimeScaleHeight } from "@/constants/themes"
+import {
+  findNextAvailableStartTime,
+  getTrackAtPointY,
+  getTrackCategory,
+  hasTrackOverlap,
+  isPreviewCategory,
+  outputTypeForCategory,
+  snapTimeToStep,
+} from "@/utils/timelineAuthoring"
 
 export const useTimeline = create<TimelineStore>((set, get) => ({
   ...getDefaultState(),
@@ -554,7 +563,19 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         }, null, 2))
       */
 
-      const { cellWidth, containerWidth, durationInMsPerStep, setSelectedSegment, setHoveredSegment, setEditedSegment } = get()
+      const {
+        cellWidth,
+        containerWidth,
+        durationInMsPerStep,
+        setSelectedSegment,
+        setHoveredSegment,
+        setEditedSegment,
+        setSelectedTrack,
+        startSegmentDrag,
+        updateSegmentDrag,
+        finishSegmentDrag,
+        timelineDrag,
+      } = get()
 
       const durationInSteps = (
         (segment.endTimeInMs - segment.startTimeInMs) / durationInMsPerStep
@@ -616,15 +637,22 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
           segment,
           status: SegmentEditionStatus.EDITING
         })
-      } else if (
-        eventType === SegmentPointerEvent.CLICK ||
-        eventType === SegmentPointerEvent.DOWN ||
-        eventType === SegmentPointerEvent.MOVE
-      ) {
+      } else if (eventType === SegmentPointerEvent.CLICK) {
         setHoveredSegment({
           segment,
           area
         })
+        setSelectedSegment({
+          segment,
+          onlyOneSelectedAtOnce: true,
+        })
+        setSelectedTrack(segment.track)
+      } else if (eventType === SegmentPointerEvent.DOWN) {
+        setHoveredSegment({
+          segment,
+          area
+        })
+        setSelectedTrack(segment.track)
         if (area === SegmentArea.LEFT) {
           setEditedSegment({
             segment,
@@ -637,8 +665,31 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
           })
         } else if (area === SegmentArea.MIDDLE) {
           setEditedSegment({
-          segment,
+            segment,
             status: SegmentEditionStatus.DRAGGING
+          })
+          startSegmentDrag({
+            segment,
+            pointX,
+            pointY: event.point.y,
+          })
+          const pointerId = (event as unknown as { pointerId?: number }).pointerId
+          const pointerTarget = event.target as unknown as { setPointerCapture?: (pointerId: number) => void }
+          if (typeof pointerId === "number") {
+            pointerTarget.setPointerCapture?.(pointerId)
+          }
+        }
+      } else if (eventType === SegmentPointerEvent.MOVE) {
+        if (timelineDrag?.segmentId === segment.id) {
+          updateSegmentDrag({
+            segment,
+            pointX,
+            pointY: event.point.y,
+          })
+        } else {
+          setHoveredSegment({
+            segment,
+            area
           })
         }
       } else if (eventType === SegmentPointerEvent.UP) {
@@ -649,6 +700,12 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         setEditedSegment({
           segment: undefined,
         })
+        finishSegmentDrag()
+        const pointerId = (event as unknown as { pointerId?: number }).pointerId
+        const pointerTarget = event.target as unknown as { releasePointerCapture?: (pointerId: number) => void }
+        if (typeof pointerId === "number") {
+          pointerTarget.releasePointerCapture?.(pointerId)
+        }
       }
 
       event.stopPropagation()
@@ -729,6 +786,415 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         durationInMs,
       })
     })
+  },
+  setSelectedTrack: (selectedTrackId?: number) => {
+    set({ selectedTrackId })
+  },
+  setSelectedTrackCategory: (selectedTrackCategory: ClapSegmentCategory) => {
+    set({ selectedTrackCategory })
+  },
+  createTrack: (requestedCategory?: ClapSegmentCategory): number => {
+    const {
+      width,
+      height,
+      tracks,
+      cellWidth,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs,
+      defaultPreviewHeight,
+      defaultCellHeight,
+      selectedTrackCategory,
+    } = get()
+
+    const category = requestedCategory || selectedTrackCategory
+    const trackId = tracks.reduce((max, track) => Math.max(max, track?.id ?? -1), -1) + 1
+    const isPreview = isPreviewCategory(category)
+    const nextTracks = [...tracks]
+
+    nextTracks[trackId] = {
+      id: trackId,
+      name: category,
+      isPreview,
+      height: isPreview ? defaultPreviewHeight : defaultCellHeight,
+      hue: 0,
+      occupied: false,
+      visible: true,
+    }
+
+    set({
+      selectedTrackId: trackId,
+      selectedTrackCategory: category,
+      ...computeContentSizeMetrics({
+        width,
+        height,
+        tracks: nextTracks,
+        cellWidth,
+        defaultSegmentDurationInSteps,
+        durationInMsPerStep,
+        durationInMs,
+      })
+    })
+
+    return trackId
+  },
+  setTrackCategory: (trackId: number, category: ClapSegmentCategory): boolean => {
+    const {
+      width,
+      height,
+      tracks,
+      segments,
+      cellWidth,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs,
+      defaultPreviewHeight,
+      defaultCellHeight,
+    } = get()
+    const track = tracks[trackId]
+
+    if (!track) {
+      return false
+    }
+
+    const trackSegments = segments.filter(segment => segment.track === trackId)
+    if (trackSegments.some(segment => segment.category !== category)) {
+      return false
+    }
+
+    const isPreview = isPreviewCategory(category)
+    const nextTracks = [...tracks]
+    nextTracks[trackId] = {
+      ...track,
+      name: category,
+      isPreview,
+      height: isPreview ? defaultPreviewHeight : defaultCellHeight,
+      occupied: track.occupied || trackSegments.length > 0,
+    }
+
+    set({
+      selectedTrackId: trackId,
+      selectedTrackCategory: category,
+      ...computeContentSizeMetrics({
+        width,
+        height,
+        tracks: nextTracks,
+        cellWidth,
+        defaultSegmentDurationInSteps,
+        durationInMsPerStep,
+        durationInMs,
+      })
+    })
+
+    return true
+  },
+  createClipOnTrack: async ({
+    trackId: requestedTrackId,
+    category: requestedCategory,
+    startTimeInMs: requestedStartTimeInMs,
+    durationInMs: requestedDurationInMs,
+  }: {
+    trackId?: number
+    category?: ClapSegmentCategory
+    startTimeInMs?: number
+    durationInMs?: number
+  } = {}): Promise<TimelineSegment | undefined> => {
+    const {
+      addSegment,
+      createTrack,
+      cursorTimestampAtInMs,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      selectedTrackCategory,
+      selectedTrackId,
+      segments,
+      setTrackCategory,
+      tracks,
+    } = get()
+
+    const category = requestedCategory || selectedTrackCategory
+    const trackId = typeof requestedTrackId === "number"
+      ? requestedTrackId
+      : typeof selectedTrackId === "number"
+      ? selectedTrackId
+      : createTrack(category)
+    const track = tracks[trackId] || get().tracks[trackId]
+
+    if (!track) {
+      return undefined
+    }
+
+    const trackCategory = getTrackCategory(track)
+    const trackSegments = segments.filter(segment => segment.track === trackId)
+    if (trackCategory && trackCategory !== category) {
+      return undefined
+    }
+    if (!trackCategory && trackSegments.length && trackSegments.some(segment => segment.category !== category)) {
+      return undefined
+    }
+    if (!trackCategory && !setTrackCategory(trackId, category)) {
+      return undefined
+    }
+
+    const durationInMs = Math.max(
+      durationInMsPerStep,
+      requestedDurationInMs || defaultSegmentDurationInSteps * durationInMsPerStep
+    )
+    const initialStartTimeInMs = snapTimeToStep(
+      typeof requestedStartTimeInMs === "number" ? requestedStartTimeInMs : cursorTimestampAtInMs,
+      durationInMsPerStep
+    )
+    const startTimeInMs = findNextAvailableStartTime({
+      segments,
+      track: trackId,
+      startTimeInMs: initialStartTimeInMs,
+      durationInMs,
+    })
+    const createdAt = new Date().toISOString()
+    const segment: TimelineSegment = {
+      id: globalThis.crypto?.randomUUID?.() || `segment-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      parentId: "",
+      childrenIds: [],
+      track: trackId,
+      startTimeInMs,
+      endTimeInMs: startTimeInMs + durationInMs,
+      category,
+      entityId: "",
+      workflowId: "",
+      sceneId: "",
+      startTimeInLines: 0,
+      endTimeInLines: 0,
+      prompt: `New ${category.toLowerCase()} clip`,
+      label: `New ${category}`,
+      outputType: outputTypeForCategory(category),
+      renderId: "",
+      status: ClapSegmentStatus.TO_GENERATE,
+      assetUrl: "",
+      assetDurationInMs: durationInMs,
+      assetSourceType: ClapAssetSource.EMPTY,
+      assetFileFormat: "",
+      createdAt,
+      createdBy: "user",
+      revision: 0,
+      editedBy: "user",
+      outputGain: 1,
+      seed: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
+      visibility: SegmentVisibility.VISIBLE,
+      textures: {},
+      colors: {
+        baseHue: 0,
+        baseSaturation: 0,
+        baseLightness: 0,
+        backgroundColor: "",
+        backgroundColorHover: "",
+        backgroundColorDisabled: "",
+        foregroundColor: "",
+        borderColor: "",
+        textColor: "",
+        textColorHover: "",
+        waveformLineSpacing: 0,
+        waveformGradientStart: 0,
+        waveformGradientEnd: 0,
+      },
+      isSelected: false,
+      isHovered: false,
+      isHoveredOnBody: false,
+      isHoveredOnLeftHandle: false,
+      isHoveredOnRightHandle: false,
+      isGrabbedOnBody: false,
+      isGrabbedOnLeftHandle: false,
+      isGrabbedOnRightHandle: false,
+      isActive: false,
+      isPlaying: false,
+      editionStatus: SegmentEditionStatus.EDITABLE,
+    }
+
+    await addSegment({
+      segment,
+      startTimeInMs,
+      track: trackId,
+    })
+
+    return segment
+  },
+  moveSegment: ({
+    segment,
+    track: requestedTrack,
+    startTimeInMs: requestedStartTimeInMs,
+  }: {
+    segment: TimelineSegment
+    track?: number
+    startTimeInMs?: number
+  }): boolean => {
+    const {
+      width,
+      height,
+      tracks,
+      segments,
+      cellWidth,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs: previousDurationInMs,
+      defaultPreviewHeight,
+      defaultCellHeight,
+      allSegmentsChanged,
+      atLeastOneSegmentChanged,
+      silentChangesInSegment,
+    } = get()
+
+    const targetTrackId = typeof requestedTrack === "number" ? requestedTrack : segment.track
+    const targetTrack = tracks[targetTrackId]
+    if (!targetTrack) {
+      return false
+    }
+
+    const isSameTrack = targetTrackId === segment.track
+    const targetCategory = getTrackCategory(targetTrack)
+    const targetTrackSegments = segments.filter(candidate => candidate.track === targetTrackId && candidate.id !== segment.id)
+    if (!isSameTrack && targetCategory && targetCategory !== segment.category) {
+      return false
+    }
+    if (
+      !isSameTrack &&
+      !targetCategory &&
+      targetTrackSegments.length &&
+      targetTrackSegments.some(candidate => candidate.category !== segment.category)
+    ) {
+      return false
+    }
+
+    const durationInMs = segment.endTimeInMs - segment.startTimeInMs
+    const startTimeInMs = snapTimeToStep(
+      typeof requestedStartTimeInMs === "number" ? requestedStartTimeInMs : segment.startTimeInMs,
+      durationInMsPerStep
+    )
+    const endTimeInMs = startTimeInMs + durationInMs
+
+    if (hasTrackOverlap({
+      segments,
+      track: targetTrackId,
+      startTimeInMs,
+      endTimeInMs,
+      excludeSegmentId: segment.id,
+    })) {
+      return false
+    }
+
+    const nextTracks = [...tracks]
+    if (!targetCategory && targetTrackSegments.length === 0) {
+      const isPreview = isPreviewCategory(segment.category)
+      nextTracks[targetTrackId] = {
+        ...targetTrack,
+        name: segment.category,
+        isPreview,
+        height: isPreview ? defaultPreviewHeight : defaultCellHeight,
+        occupied: true,
+      }
+    } else if (!targetTrack.occupied) {
+      nextTracks[targetTrackId] = {
+        ...targetTrack,
+        occupied: true,
+      }
+    }
+
+    const previousTrack = nextTracks[segment.track]
+    segment.track = targetTrackId
+    segment.startTimeInMs = startTimeInMs
+    segment.endTimeInMs = endTimeInMs
+    silentChangesInSegment[segment.id] = 1 + (silentChangesInSegment[segment.id] || 0)
+
+    if (previousTrack && previousTrack.id !== targetTrackId) {
+      const previousStillOccupied = segments.some(candidate => (
+        candidate.id !== segment.id && candidate.track === previousTrack.id
+      ))
+      nextTracks[previousTrack.id] = {
+        ...previousTrack,
+        occupied: previousStillOccupied,
+      }
+    }
+
+    const durationInMsAfterMove = Math.max(previousDurationInMs, endTimeInMs)
+
+    set({
+      segments,
+      loadedSegments: [],
+      silentChangesInSegment,
+      durationInMs: durationInMsAfterMove,
+      selectedTrackId: targetTrackId,
+      selectedTrackCategory: segment.category,
+      allSegmentsChanged: allSegmentsChanged + 1,
+      atLeastOneSegmentChanged: atLeastOneSegmentChanged + 1,
+      ...computeContentSizeMetrics({
+        width,
+        height,
+        tracks: nextTracks,
+        cellWidth,
+        defaultSegmentDurationInSteps,
+        durationInMsPerStep,
+        durationInMs: durationInMsAfterMove,
+      })
+    })
+
+    return true
+  },
+  startSegmentDrag: ({
+    segment,
+    pointX,
+    pointY,
+  }: {
+    segment: TimelineSegment
+    pointX: number
+    pointY: number
+  }) => {
+    set({
+      timelineDrag: {
+        segmentId: segment.id,
+        pointX,
+        pointY,
+        startTimeInMs: segment.startTimeInMs,
+        endTimeInMs: segment.endTimeInMs,
+        track: segment.track,
+      }
+    })
+  },
+  updateSegmentDrag: ({
+    segment,
+    pointX,
+    pointY,
+  }: {
+    segment: TimelineSegment
+    pointX: number
+    pointY: number
+  }) => {
+    const {
+      timelineDrag,
+      cellWidth,
+      durationInMsPerStep,
+      tracks,
+      defaultCellHeight,
+      moveSegment,
+    } = get()
+
+    if (!timelineDrag || timelineDrag.segmentId !== segment.id || cellWidth <= 0) {
+      return
+    }
+
+    const deltaInSteps = Math.round((pointX - timelineDrag.pointX) / cellWidth)
+    const startTimeInMs = timelineDrag.startTimeInMs + (deltaInSteps * durationInMsPerStep)
+    const track = getTrackAtPointY({
+      tracks,
+      pointY,
+      defaultCellHeight,
+    }) ?? timelineDrag.track
+
+    moveSegment({
+      segment,
+      track,
+      startTimeInMs,
+    })
+  },
+  finishSegmentDrag: () => {
+    set({ timelineDrag: undefined })
   },
   setContainerSize: ({ width, height }: { width: number; height: number }) => {
     const { containerWidth: previousWidth, containerHeight: previousHeight } = get()
@@ -899,8 +1365,6 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
 
     segment.track = track
    
-    let nbTracks = tracks.length
-
     // add the track if it is missing
     if (!tracks[segment.track]) {
       const isPreview =
@@ -919,6 +1383,24 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         hue: 0,
         occupied: true,
         visible: true,
+      }
+    } else if (!tracks[segment.track].occupied) {
+      const track = tracks[segment.track]
+      const category = getTrackCategory(track)
+      const isPreview =
+        segment.category === ClapSegmentCategory.IMAGE ||
+        segment.category === ClapSegmentCategory.VIDEO
+
+      tracks[segment.track] = {
+        ...track,
+        name: category || `${segment.category}`,
+        isPreview: category ? track.isPreview : isPreview,
+        height: category
+          ? track.height
+          : isPreview
+          ? defaultPreviewHeight
+          : defaultCellHeight,
+        occupied: true,
       }
     }
 
@@ -972,6 +1454,8 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     const startTimeInMs = isValidNumber(requestedStartTimeInMs) ? requestedStartTimeInMs! : segment.startTimeInMs
 
     const endTimeInMs = startTimeInMs + segmentDuration
+    segment.startTimeInMs = startTimeInMs
+    segment.endTimeInMs = endTimeInMs
 
     // for now let's do something simple: to always search for an available track
     const availableTrack = isValidNumber(requestedTrack) ? requestedTrack! : findFreeTrack({

--- a/packages/timeline/src/types/timeline.ts
+++ b/packages/timeline/src/types/timeline.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three"
 import type { ThreeEvent } from "@react-three/fiber"
-import { ClapEntity, ClapImageRatio, ClapMeta, ClapProject, ClapScene, ClapSegment, ClapTracks } from "@aitube/clap"
+import { ClapEntity, ClapImageRatio, ClapMeta, ClapProject, ClapScene, ClapSegment, ClapSegmentCategory, ClapTracks } from "@aitube/clap"
 
 import { ClapSegmentColorScheme, ClapTimelineTheme } from "./theme"
 import { TimelineControlsImpl } from "@/components/controls/types"
@@ -228,6 +228,19 @@ export type TimelineStoreProjectState = ClapMeta & {
 
   // position of the current timestamp
   cursorTimestampAtInMs: number
+
+  selectedTrackId?: number
+  selectedTrackCategory: ClapSegmentCategory
+  timelineDrag?: TimelineDragState
+}
+
+export type TimelineDragState = {
+  segmentId: string
+  pointX: number
+  pointY: number
+  startTimeInMs: number
+  endTimeInMs: number
+  track: number
 }
 
 export type TimelineStorePreferencesState = {
@@ -327,6 +340,32 @@ export type TimelineStoreModifiers = {
   setScrollX: (scrollX: number) => void
   handleMouseWheel: ({ deltaX, deltaY }: { deltaX: number; deltaY: number }) => void
   toggleTrackVisibility: (trackId: number) => void
+  setSelectedTrack: (trackId?: number) => void
+  setSelectedTrackCategory: (category: ClapSegmentCategory) => void
+  createTrack: (category?: ClapSegmentCategory) => number
+  setTrackCategory: (trackId: number, category: ClapSegmentCategory) => boolean
+  createClipOnTrack: (params?: {
+    trackId?: number
+    category?: ClapSegmentCategory
+    startTimeInMs?: number
+    durationInMs?: number
+  }) => Promise<TimelineSegment | undefined>
+  moveSegment: (params: {
+    segment: TimelineSegment
+    track?: number
+    startTimeInMs?: number
+  }) => boolean
+  startSegmentDrag: (params: {
+    segment: TimelineSegment
+    pointX: number
+    pointY: number
+  }) => void
+  updateSegmentDrag: (params: {
+    segment: TimelineSegment
+    pointX: number
+    pointY: number
+  }) => void
+  finishSegmentDrag: () => void
   setContainerSize: ({ width, height }: { width: number; height: number }) => void
   setTimelineCursor: (timelineCursor?: TimelineCursorImpl) => void
   setIsDraggingCursor: (isDraggingCursor: boolean) => void

--- a/packages/timeline/src/utils/getDefaultState.ts
+++ b/packages/timeline/src/utils/getDefaultState.ts
@@ -1,4 +1,4 @@
-import { ClapMeta, newClap } from "@aitube/clap"
+import { ClapMeta, ClapSegmentCategory, newClap } from "@aitube/clap"
 
 import { DEFAULT_NB_TRACKS, pastel, PROMPT_STEP_HEIGHT_IN_PX } from "@/constants"
 import { TimelineStorePreferencesState, TimelineStoreProjectState, TimelineStoreState } from "@/types/timeline"
@@ -67,6 +67,9 @@ export function getDefaultProjectState(): TimelineStoreProjectState {
     
     cursorTimestampAtInMs: 0,
     isDraggingCursor: false,
+    selectedTrackId: undefined,
+    selectedTrackCategory: ClapSegmentCategory.VIDEO,
+    timelineDrag: undefined,
   }
 }
 

--- a/packages/timeline/src/utils/timelineAuthoring.test.ts
+++ b/packages/timeline/src/utils/timelineAuthoring.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test"
+import { ClapOutputType, ClapSegmentCategory, ClapTrack } from "@aitube/clap"
+
+import {
+  findNextAvailableStartTime,
+  getTrackAtPointY,
+  getTrackCategory,
+  hasTrackOverlap,
+  outputTypeForCategory,
+  snapTimeToStep,
+} from "./timelineAuthoring"
+
+const segments = [
+  {
+    id: "video-1",
+    track: 1,
+    startTimeInMs: 1000,
+    endTimeInMs: 2000,
+  },
+  {
+    id: "video-2",
+    track: 1,
+    startTimeInMs: 2500,
+    endTimeInMs: 3000,
+  },
+  {
+    id: "audio-1",
+    track: 2,
+    startTimeInMs: 1000,
+    endTimeInMs: 2000,
+  },
+]
+
+describe("timeline authoring helpers", () => {
+  test("snaps times to the nearest positive step", () => {
+    expect(snapTimeToStep(1240, 500)).toBe(1000)
+    expect(snapTimeToStep(1260, 500)).toBe(1500)
+    expect(snapTimeToStep(-125, 500)).toBe(0)
+  })
+
+  test("detects overlaps only on the requested track", () => {
+    expect(hasTrackOverlap({
+      segments,
+      track: 1,
+      startTimeInMs: 1500,
+      endTimeInMs: 1800,
+    })).toBe(true)
+
+    expect(hasTrackOverlap({
+      segments,
+      track: 1,
+      startTimeInMs: 2000,
+      endTimeInMs: 2400,
+    })).toBe(false)
+
+    expect(hasTrackOverlap({
+      segments,
+      track: 1,
+      startTimeInMs: 1500,
+      endTimeInMs: 1800,
+      excludeSegmentId: "video-1",
+    })).toBe(false)
+  })
+
+  test("places new clips after existing conflicts", () => {
+    expect(findNextAvailableStartTime({
+      segments,
+      track: 1,
+      startTimeInMs: 1500,
+      durationInMs: 500,
+    })).toBe(2000)
+
+    expect(findNextAvailableStartTime({
+      segments,
+      track: 1,
+      startTimeInMs: 1800,
+      durationInMs: 900,
+    })).toBe(3000)
+  })
+
+  test("maps categories to render output types", () => {
+    expect(outputTypeForCategory(ClapSegmentCategory.VIDEO)).toBe(ClapOutputType.VIDEO)
+    expect(outputTypeForCategory(ClapSegmentCategory.IMAGE)).toBe(ClapOutputType.IMAGE)
+    expect(outputTypeForCategory(ClapSegmentCategory.DIALOGUE)).toBe(ClapOutputType.AUDIO)
+    expect(outputTypeForCategory(ClapSegmentCategory.ACTION)).toBe(ClapOutputType.TEXT)
+  })
+
+  test("reads explicit track categories and rejects mixed labels", () => {
+    expect(getTrackCategory({ name: ClapSegmentCategory.VIDEO } as ClapTrack)).toBe(ClapSegmentCategory.VIDEO)
+    expect(getTrackCategory({ name: "(misc)" } as ClapTrack)).toBeUndefined()
+  })
+
+  test("finds a track from a vertical scene point", () => {
+    const tracks = [
+      { id: 0, height: 10 },
+      { id: 1, height: 20 },
+      { id: 2, height: 10 },
+    ] as ClapTrack[]
+
+    expect(getTrackAtPointY({ tracks, pointY: -5, defaultCellHeight: 10 })).toBe(0)
+    expect(getTrackAtPointY({ tracks, pointY: -15, defaultCellHeight: 10 })).toBe(1)
+    expect(getTrackAtPointY({ tracks, pointY: -35, defaultCellHeight: 10 })).toBe(2)
+    expect(getTrackAtPointY({ tracks, pointY: -45, defaultCellHeight: 10 })).toBeUndefined()
+  })
+})

--- a/packages/timeline/src/utils/timelineAuthoring.ts
+++ b/packages/timeline/src/utils/timelineAuthoring.ts
@@ -1,0 +1,175 @@
+import {
+  ClapOutputType,
+  ClapSegmentCategory,
+  ClapTrack,
+  ClapTracks,
+} from "@aitube/clap"
+
+export const TIMELINE_AUTHORING_CATEGORIES: ClapSegmentCategory[] = [
+  ClapSegmentCategory.VIDEO,
+  ClapSegmentCategory.IMAGE,
+  ClapSegmentCategory.DIALOGUE,
+  ClapSegmentCategory.SOUND,
+  ClapSegmentCategory.MUSIC,
+  ClapSegmentCategory.ACTION,
+  ClapSegmentCategory.CAMERA,
+  ClapSegmentCategory.GENERIC,
+]
+
+const TRACK_CATEGORY_VALUES = new Set<string>(Object.values(ClapSegmentCategory))
+
+export function getTrackCategory(track?: ClapTrack): ClapSegmentCategory | undefined {
+  if (!track || !TRACK_CATEGORY_VALUES.has(track.name)) {
+    return undefined
+  }
+
+  return track.name as ClapSegmentCategory
+}
+
+export function isPreviewCategory(category: ClapSegmentCategory): boolean {
+  return category === ClapSegmentCategory.IMAGE || category === ClapSegmentCategory.VIDEO
+}
+
+export function outputTypeForCategory(category: ClapSegmentCategory): ClapOutputType {
+  if (category === ClapSegmentCategory.IMAGE) {
+    return ClapOutputType.IMAGE
+  }
+  if (category === ClapSegmentCategory.VIDEO) {
+    return ClapOutputType.VIDEO
+  }
+  if (
+    category === ClapSegmentCategory.DIALOGUE ||
+    category === ClapSegmentCategory.SOUND ||
+    category === ClapSegmentCategory.MUSIC
+  ) {
+    return ClapOutputType.AUDIO
+  }
+  if (category === ClapSegmentCategory.TRANSITION) {
+    return ClapOutputType.TRANSITION
+  }
+  if (category === ClapSegmentCategory.EVENT) {
+    return ClapOutputType.EVENT
+  }
+  if (category === ClapSegmentCategory.INTERFACE) {
+    return ClapOutputType.INTERFACE
+  }
+  if (category === ClapSegmentCategory.PHENOMENON) {
+    return ClapOutputType.PHENOMENON
+  }
+
+  return ClapOutputType.TEXT
+}
+
+export function snapTimeToStep(timeInMs: number, stepInMs: number): number {
+  if (!Number.isFinite(timeInMs) || !Number.isFinite(stepInMs) || stepInMs <= 0) {
+    return Math.max(0, timeInMs || 0)
+  }
+
+  return Math.max(0, Math.round(timeInMs / stepInMs) * stepInMs)
+}
+
+export function segmentRangesOverlap(
+  firstStartInMs: number,
+  firstEndInMs: number,
+  secondStartInMs: number,
+  secondEndInMs: number
+): boolean {
+  return firstStartInMs < secondEndInMs && secondStartInMs < firstEndInMs
+}
+
+export function hasTrackOverlap({
+  segments,
+  track,
+  startTimeInMs,
+  endTimeInMs,
+  excludeSegmentId,
+}: {
+  segments: Array<{
+    id: string
+    track: number
+    startTimeInMs: number
+    endTimeInMs: number
+  }>
+  track: number
+  startTimeInMs: number
+  endTimeInMs: number
+  excludeSegmentId?: string
+}): boolean {
+  return segments.some(segment => (
+    segment.track === track &&
+    segment.id !== excludeSegmentId &&
+    segmentRangesOverlap(
+      startTimeInMs,
+      endTimeInMs,
+      segment.startTimeInMs,
+      segment.endTimeInMs
+    )
+  ))
+}
+
+export function findNextAvailableStartTime({
+  segments,
+  track,
+  startTimeInMs,
+  durationInMs,
+  excludeSegmentId,
+}: {
+  segments: Array<{
+    id: string
+    track: number
+    startTimeInMs: number
+    endTimeInMs: number
+  }>
+  track: number
+  startTimeInMs: number
+  durationInMs: number
+  excludeSegmentId?: string
+}): number {
+  let candidateStart = Math.max(0, startTimeInMs)
+  let candidateEnd = candidateStart + durationInMs
+  let moved = true
+
+  while (moved) {
+    moved = false
+    for (const segment of segments) {
+      if (segment.track !== track || segment.id === excludeSegmentId) {
+        continue
+      }
+      if (segmentRangesOverlap(candidateStart, candidateEnd, segment.startTimeInMs, segment.endTimeInMs)) {
+        candidateStart = segment.endTimeInMs
+        candidateEnd = candidateStart + durationInMs
+        moved = true
+      }
+    }
+  }
+
+  return candidateStart
+}
+
+export function getTrackAtPointY({
+  tracks,
+  pointY,
+  defaultCellHeight,
+}: {
+  tracks: ClapTracks
+  pointY: number
+  defaultCellHeight: number
+}): number | undefined {
+  let trackTop = 0
+
+  for (const track of tracks) {
+    if (!track) {
+      continue
+    }
+    const trackHeight = track.height || defaultCellHeight
+    const trackBottom = trackTop - trackHeight
+
+    if (pointY <= trackTop && pointY >= trackBottom) {
+      return track.id
+    }
+
+    trackTop = trackBottom
+  }
+
+  return undefined
+}


### PR DESCRIPTION
Closes #10.

## Summary
- Adds a compact timeline authoring toolbar for choosing a track, choosing a clip type, creating typed tracks, and creating clips on the selected track.
- Adds store actions for track selection, track category assignment, typed clip creation, segment moving, and drag lifecycle state.
- Keeps clips type-compatible with their destination track, avoids clip overlap on creation and moves, snaps movement to timeline steps, clamps negative starts to zero, and preserves legacy mixed-track horizontal movement.
- Adds focused coverage for the authoring helper logic that powers overlap checks, placement, category mapping, and track hit testing.

## Validation
- `npx --yes bun run --cwd packages/clap build`
- `npx --yes bun test packages/timeline/src/utils/timelineAuthoring.test.ts`
- `npx --yes bun run --cwd packages/timeline build:declaration`
- `npx --yes bun run --cwd packages/timeline build`
- `git diff --check`
- Browser smoke test against the timeline Vite demo: toolbar rendered, `+ Track` and `+ Clip` controls were unique/clickable, a new track appeared, and no console warnings/errors were reported.