### PR TITLE
Fix ComfyUI workflow provider id

### DIFF
--- a/packages/clap/src/types.ts
+++ b/packages/clap/src/types.ts
@@ -661,7 +661,7 @@ export enum ClapWorkflowProvider {
   COHERE = "COHERE", // https://cohere.com
   COMFYDEPLOY = "COMFYDEPLOY", // https://comfydeploy.com
   COMFYICU = "COMFYICU", // https://comfy.icu
-  COMFYUI = "COMFUI", // any ComfyUI server (local or remote)
+  COMFYUI = "COMFYUI", // any ComfyUI server (local or remote)
   ELEVENLABS = "ELEVENLABS", // https://elevenlabs.io
   EVERARTAI = "EVERARTAI",
   FALAI = "FALAI", // https://fal.ai

--- a/packages/clap/src/utils/parseWorkflowProvider.ts
+++ b/packages/clap/src/utils/parseWorkflowProvider.ts
@@ -4,6 +4,14 @@ export function parseWorkflowProvider(input: any, defaultToUse?: ClapWorkflowPro
     
   let unknownString = `${input || ""}`.trim()
 
+  // Backward compatibility for workflows saved before the COMFYUI provider
+  // string was corrected.
+  if (unknownString === "COMFUI") {
+    return ClapWorkflowProvider.COMFYUI
+  }
+
+  unknownString = unknownString.toUpperCase()
+
   // the "normal" case
   if (Object.values(ClapWorkflowProvider).includes(unknownString as ClapWorkflowProvider)) {
     return unknownString as ClapWorkflowProvider


### PR DESCRIPTION
Related to #5.

This fixes a small but important ComfyUI integration issue: `ClapWorkflowProvider.COMFYUI` currently serializes as `"COMFUI"` instead of `"COMFYUI"`.

The resolver and settings code refer to `ClapWorkflowProvider.COMFYUI`, so persisted or imported workflow/provider values should use the correctly spelled provider id.

Changes:

- correct the enum value to `"COMFYUI"`
- keep backward compatibility by parsing the old `"COMFUI"` value as `ClapWorkflowProvider.COMFYUI`
- normalize provider input to uppercase so lower-case imported provider values like `"comfyui"` resolve correctly

I could not run the Bun build in this environment because `bun` is not installed here, but the patch is intentionally small and limited to provider parsing/types.
