### PR TITLE
Add timeline track and clip creation controls

### DIFF
--- a/packages/app/src/components/core/timeline/index.tsx
+++ b/packages/app/src/components/core/timeline/index.tsx
@@ -1,9 +1,21 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { ClapSegmentCategory } from '@aitube/clap'
 import { ClapTimeline, useTimeline, SegmentResolver } from '@aitube/timeline'
 
 import { useMonitor } from '@/services/monitor/useMonitor'
 import { useResolver } from '@/services/resolver/useResolver'
 import { useUI } from '@/services/ui'
+
+const creativeTrackCategories = [
+  ClapSegmentCategory.VIDEO,
+  ClapSegmentCategory.IMAGE,
+  ClapSegmentCategory.DIALOGUE,
+  ClapSegmentCategory.MUSIC,
+  ClapSegmentCategory.SOUND,
+  ClapSegmentCategory.ACTION,
+  ClapSegmentCategory.CAMERA,
+  ClapSegmentCategory.GENERIC,
+]
 
 export function Timeline(
   {
@@ -15,6 +27,18 @@ export function Timeline(
   }
 ) {
   const isReady = useTimeline((s) => s.isReady)
+  const tracks = useTimeline((s) => s.tracks)
+  const createTrack = useTimeline((s) => s.createTrack)
+  const createClip = useTimeline((s) => s.createClip)
+  const [category, setCategory] = useState<ClapSegmentCategory>(
+    ClapSegmentCategory.VIDEO
+  )
+  const [trackId, setTrackId] = useState<number | 'new'>('new')
+
+  const selectableTracks = useMemo(
+    () => tracks.filter((track) => track.visible),
+    [tracks]
+  )
 
   const resolveSegment: SegmentResolver = useResolver((s) => s.resolveSegment)
   const setSegmentResolver = useTimeline((s) => s.setSegmentResolver)
@@ -56,13 +80,83 @@ export function Timeline(
     togglePlayback,
   ])
 
+  const handleCreateTrack = () => {
+    const newTrackId = createTrack({ category })
+    setTrackId(newTrackId)
+  }
+
+  const handleCreateClip = async () => {
+    await createClip({
+      category,
+      track: trackId === 'new' ? undefined : trackId,
+    })
+  }
+
+  const timeline = <ClapTimeline showFPS={false} />
+
+  const timelineCreationControls = (
+    <div className="absolute right-3 top-3 z-20 flex items-center gap-2 rounded-md border border-white/15 bg-black/75 p-2 text-xs text-white shadow-lg backdrop-blur">
+      <select
+        aria-label="Track type"
+        className="h-8 rounded border border-white/20 bg-neutral-900 px-2 text-white"
+        value={category}
+        onChange={(event) =>
+          setCategory(event.target.value as ClapSegmentCategory)
+        }
+      >
+        {creativeTrackCategories.map((trackCategory) => (
+          <option key={trackCategory} value={trackCategory}>
+            {trackCategory}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label="Target track"
+        className="h-8 rounded border border-white/20 bg-neutral-900 px-2 text-white"
+        value={trackId}
+        onChange={(event) => {
+          setTrackId(
+            event.target.value === 'new' ? 'new' : Number(event.target.value)
+          )
+        }}
+      >
+        <option value="new">New track</option>
+        {selectableTracks.map((track) => (
+          <option key={track.id} value={track.id}>
+            Track {track.id}: {track.name}
+          </option>
+        ))}
+      </select>
+      <button
+        className="h-8 rounded bg-white px-3 font-medium text-black hover:bg-white/90"
+        type="button"
+        onClick={handleCreateTrack}
+      >
+        Add track
+      </button>
+      <button
+        className="h-8 rounded bg-cyan-400 px-3 font-medium text-black hover:bg-cyan-300"
+        type="button"
+        onClick={handleCreateClip}
+      >
+        Add clip
+      </button>
+    </div>
+  )
+
   if (className) {
     return (
-      <div className={className}>
-        <ClapTimeline showFPS={false} />
+      <div className={`relative ${className}`}>
+        {timelineCreationControls}
+        {timeline}
       </div>
     )
   }
 
-  return <ClapTimeline showFPS={false} className={className} />
+  return (
+    <div className="relative h-full w-full">
+      {timelineCreationControls}
+      {timeline}
+    </div>
+  )
 }

--- a/packages/timeline/src/hooks/useTimeline.ts
+++ b/packages/timeline/src/hooks/useTimeline.ts
@@ -1,18 +1,75 @@
-import { create } from "zustand"
-import * as THREE from "three"
-import type { ThreeEvent } from "@react-three/fiber"
-import { ClapProject, ClapSegment, ClapSegmentCategory, isValidNumber, newClap, serializeClap, ClapTracks, ClapEntity, ClapMeta } from "@aitube/clap"
+import { create } from 'zustand'
+import * as THREE from 'three'
+import type { ThreeEvent } from '@react-three/fiber'
+import {
+  ClapProject,
+  ClapSegment,
+  ClapSegmentCategory,
+  isValidNumber,
+  newClap,
+  serializeClap,
+  ClapTracks,
+  ClapEntity,
+  ClapMeta,
+  ClapOutputType,
+  ClapSegmentStatus,
+  ClapAssetSource,
+} from '@aitube/clap'
 
-import { TimelineSegment, SegmentEditionStatus, SegmentVisibility, TimelineStore, SegmentArea, SegmentPointerEvent, SegmentEventCallbackHandler, Invalidate } from "@/types/timeline"
-import { getDefaultProjectState, getDefaultState } from "@/utils/getDefaultState"
-import { DEFAULT_NB_TRACKS, leftBarTrackScaleWidth } from "@/constants"
-import { findFreeTrack, removeFinalVideosAndConvertToTimelineSegments, clapSegmentToTimelineSegment, timelineSegmentToClapSegment } from "@/utils"
-import { ClapTimelineTheme, SegmentResolver } from "@/types"
-import { TimelineControlsImpl } from "@/components/controls/types"
-import { TimelineCameraImpl } from "@/components/camera/types"
-import { IsPlaying, JumpAt, TimelineCursorImpl, TogglePlayback } from "@/components/timeline/types"
-import { computeContentSizeMetrics } from "@/compute/computeContentSizeMetrics"
-import { topBarTimeScaleHeight } from "@/constants/themes"
+import {
+  TimelineSegment,
+  SegmentEditionStatus,
+  SegmentVisibility,
+  TimelineStore,
+  SegmentArea,
+  SegmentPointerEvent,
+  SegmentEventCallbackHandler,
+  Invalidate,
+  CreateTrackParams,
+  CreateClipParams,
+} from '@/types/timeline'
+import { getDefaultProjectState, getDefaultState } from '@/utils/getDefaultState'
+import { DEFAULT_NB_TRACKS, leftBarTrackScaleWidth } from '@/constants'
+import {
+  findFreeTrack,
+  removeFinalVideosAndConvertToTimelineSegments,
+  clapSegmentToTimelineSegment,
+  timelineSegmentToClapSegment,
+} from '@/utils'
+import { ClapTimelineTheme, SegmentResolver } from '@/types'
+import { TimelineControlsImpl } from '@/components/controls/types'
+import { TimelineCameraImpl } from '@/components/camera/types'
+import { IsPlaying, JumpAt, TimelineCursorImpl, TogglePlayback } from '@/components/timeline/types'
+import { computeContentSizeMetrics } from '@/compute/computeContentSizeMetrics'
+import { topBarTimeScaleHeight } from '@/constants/themes'
+
+const previewCategories = new Set<ClapSegmentCategory>([ClapSegmentCategory.IMAGE, ClapSegmentCategory.VIDEO])
+
+const audioCategories = new Set<ClapSegmentCategory>([ClapSegmentCategory.DIALOGUE, ClapSegmentCategory.MUSIC, ClapSegmentCategory.SOUND])
+
+function getSegmentOutputType(category: ClapSegmentCategory): ClapOutputType {
+  if (category === ClapSegmentCategory.IMAGE) {
+    return ClapOutputType.IMAGE
+  }
+  if (category === ClapSegmentCategory.VIDEO) {
+    return ClapOutputType.VIDEO
+  }
+  if (audioCategories.has(category)) {
+    return ClapOutputType.AUDIO
+  }
+  return ClapOutputType.TEXT
+}
+
+function getCategoryFromTrackName(name?: string): ClapSegmentCategory | undefined {
+  return Object.values(ClapSegmentCategory).find(category => category === name)
+}
+
+function createSegmentId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `segment-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
 
 export const useTimeline = create<TimelineStore>((set, get) => ({
   ...getDefaultState(),
@@ -24,7 +81,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
   clear: () => {
     // this re-initialize everything that is related to the current .clap project
     set({
-      ...getDefaultProjectState()
+      ...getDefaultProjectState(),
     })
   },
 
@@ -37,22 +94,18 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       console.log(`useTimeline: no clap to show`)
       return
     }
-    
+
     set({ isLoading: true })
 
     // actually you know what.. let's drop the concept of final video for the moment
     // in Clapper and the timeline
     // const finalVideo = await getFinalVideo(clap)
     const finalVideo = undefined
-    
+
     // we remove the big/long video
     const segments = await removeFinalVideosAndConvertToTimelineSegments(clap)
 
-    const {
-      defaultCellHeight,
-      durationInMsPerStep,
-      cellWidth,
-    } = get()
+    const { defaultCellHeight, durationInMsPerStep, cellWidth } = get()
 
     const meta = clap.meta
 
@@ -65,13 +118,10 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     let tracks: ClapTracks = []
 
     let defaultSegmentDurationInSteps = get().defaultSegmentDurationInSteps
- 
-  
+
     for (const s of segments) {
       if (s.category === ClapSegmentCategory.CAMERA) {
-        const durationInSteps = (
-          (s.endTimeInMs - s.startTimeInMs) / durationInMsPerStep
-        )
+        const durationInSteps = (s.endTimeInMs - s.startTimeInMs) / durationInMsPerStep
         // TODO: we should do this row by row
         // and look at the most recurring duration,
         // using a table
@@ -84,19 +134,14 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
 
     // TODO: compute the exact image ratio instead of using the media orientation,
     // since it might not match the actual assets
-    const defaultImageRatio = clap ? (
-      (clap.meta.width || 896) / (clap.meta.height || 512)
-    ) : (896 / 512)
-    
+    const defaultImageRatio = clap ? (clap.meta.width || 896) / (clap.meta.height || 512) : 896 / 512
+
     // also storyboard images and videos might have different sizes / ratios
-    const defaultPreviewHeight = Math.round(
-      defaultSegmentLengthInPixels / defaultImageRatio
-    )
+    const defaultPreviewHeight = Math.round(defaultSegmentLengthInPixels / defaultImageRatio)
 
     const lineNumberToMentionedSegments: Record<number, TimelineSegment[]> = {}
 
     for (const segment of segments) {
-      
       // TODO: move this idCollision detector into the state,
       // so that we can use it later?
       if (idCollisionDetector.has(segment.id)) {
@@ -105,8 +150,9 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       }
 
       // --------
-      const isSegmentDirectlyMentionedInTheScript = segment.category === ClapSegmentCategory.DIALOGUE || segment.category === ClapSegmentCategory.ACTION
-      
+      const isSegmentDirectlyMentionedInTheScript =
+        segment.category === ClapSegmentCategory.DIALOGUE || segment.category === ClapSegmentCategory.ACTION
+
       if (isSegmentDirectlyMentionedInTheScript) {
         for (let i = segment.startTimeInLines; i <= segment.endTimeInLines; i++) {
           // we only add the segment if it is not already in the map
@@ -121,29 +167,23 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       idCollisionDetector.add(segment.id)
 
       if (!tracks[segment.track]) {
-        const isPreview =
-        segment.category === ClapSegmentCategory.IMAGE ||
-          segment.category === ClapSegmentCategory.VIDEO
+        const isPreview = segment.category === ClapSegmentCategory.IMAGE || segment.category === ClapSegmentCategory.VIDEO
 
         tracks[segment.track] = {
           id: segment.track,
           // name: `Track ${s.track}`,
           name: `${segment.category}`,
           isPreview,
-          height:
-            isPreview
-            ? defaultPreviewHeight
-            : defaultCellHeight,
+          height: isPreview ? defaultPreviewHeight : defaultCellHeight,
           hue: 0,
           occupied: true,
           visible: true,
         }
       } else {
-        
         const track = tracks[segment.track]
-        const categories: string[] = track.name.split(",").map((x: string) => x.trim())
+        const categories: string[] = track.name.split(',').map((x: string) => x.trim())
         if (!categories.includes(segment.category)) {
-          tracks[segment.track].name = "(misc)"
+          tracks[segment.track].name = '(misc)'
 
           /*
           if (categories.length < 2) {
@@ -154,12 +194,10 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
           }
           */
         }
-        
       }
-
     }
 
-   // ---------- FILL-IN THE TRACKS ---------------
+    // ---------- FILL-IN THE TRACKS ---------------
     for (let id = 0; id < DEFAULT_NB_TRACKS; id++) {
       if (!tracks[id]) {
         tracks[id] = {
@@ -215,7 +253,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         defaultSegmentDurationInSteps,
         durationInMsPerStep,
         durationInMs,
-      })
+      }),
     })
 
     // one more thing: we need to call this,
@@ -223,24 +261,19 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     get().jumpAt(0)
   },
   getClap: async (): Promise<ClapProject> => {
-    const { 
-      getClapMeta,
-      entities,
-      scenes,
-      segments
-    } = get()
+    const { getClapMeta, entities, scenes, segments } = get()
 
     const clap = newClap({
       meta: getClapMeta(),
       entities: [...entities],
       scenes: [...scenes],
-      segments: segments.map(ts => timelineSegmentToClapSegment(ts))
+      segments: segments.map(ts => timelineSegmentToClapSegment(ts)),
     })
 
     return clap
   },
   getClapMeta: (): ClapMeta => {
-    const { 
+    const {
       id,
       title,
       description,
@@ -295,9 +328,11 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       durationInMs,
     } = get()
     const cellWidth = Math.min(maxHorizontalZoomLevel, Math.max(minHorizontalZoomLevel, newHorizontalZoomLevel))
-    
+
     // nothing changed
-    if (Math.round(cellWidth) === Math.round(previousCellWidth)) { return }
+    if (Math.round(cellWidth) === Math.round(previousCellWidth)) {
+      return
+    }
 
     const resizeStartedAt = performance.now()
     const isResizing = true
@@ -313,15 +348,19 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         defaultSegmentDurationInSteps,
         durationInMsPerStep,
         durationInMs,
-      })
+      }),
     })
   },
-  
+
   setSegments: (segments: TimelineSegment[] = []) => {
     set({ segments, loadedSegments: [] })
   },
-  setLoadedSegments: (loadedSegments: TimelineSegment[] = []) => { set({ loadedSegments }) },
-  setVisibleSegments: (visibleSegments: TimelineSegment[] = []) => { set({ visibleSegments }) },
+  setLoadedSegments: (loadedSegments: TimelineSegment[] = []) => {
+    set({ loadedSegments })
+  },
+  setVisibleSegments: (visibleSegments: TimelineSegment[] = []) => {
+    set({ visibleSegments })
+  },
 
   getCellHeight: (trackNumber?: number): number => {
     const { defaultCellHeight, tracks } = get()
@@ -343,7 +382,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     area,
   }: {
     segment?: TimelineSegment
-    area?: SegmentArea 
+    area?: SegmentArea
   } = {}) => {
     const {
       invalidate,
@@ -372,7 +411,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         set({
           hoveredSegment: segment,
           allSegmentsChanged: 1 + previousAllSegmentsChanged,
-          atLeastOneSegmentChanged: 1 + previousAtLeastOneSegmentChanged
+          atLeastOneSegmentChanged: 1 + previousAtLeastOneSegmentChanged,
         })
       }
     } else {
@@ -384,7 +423,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         set({
           hoveredSegment: undefined,
           allSegmentsChanged: 1 + previousAllSegmentsChanged,
-          atLeastOneSegmentChanged: 1 + previousAtLeastOneSegmentChanged
+          atLeastOneSegmentChanged: 1 + previousAtLeastOneSegmentChanged,
         })
       } else {
         // nothing to do
@@ -393,20 +432,22 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     // since we are un frameloop="demand" mode, we need to manual invalidate the scene
     invalidate()
   },
-  setEditedSegment: ({
-    segment,
-    status = SegmentEditionStatus.EDITING
-  }: {
-    segment?: TimelineSegment
-    status?: SegmentEditionStatus
-  } = {
-    status: SegmentEditionStatus.EDITING
-  }) => {
+  setEditedSegment: (
+    {
+      segment,
+      status = SegmentEditionStatus.EDITING,
+    }: {
+      segment?: TimelineSegment
+      status?: SegmentEditionStatus
+    } = {
+      status: SegmentEditionStatus.EDITING,
+    }
+  ) => {
     const {
       invalidate,
       editedSegment: previousEditedSegment,
       allSegmentsChanged: previousAllSegmentsChanged,
-      atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged
+      atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged,
     } = get()
 
     // since we are un frameloop="demand" mode, we need to manual invalidate the scene
@@ -426,7 +467,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         set({
           editedSegment: segment,
           atLeastOneSegmentChanged: 1 + previousAtLeastOneSegmentChanged,
-          allSegmentsChanged: 1 + previousAllSegmentsChanged
+          allSegmentsChanged: 1 + previousAllSegmentsChanged,
         })
       }
     } else {
@@ -435,7 +476,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         set({
           editedSegment: undefined,
           atLeastOneSegmentChanged: 1 + previousAtLeastOneSegmentChanged,
-          allSegmentsChanged: 1 + previousAllSegmentsChanged
+          allSegmentsChanged: 1 + previousAllSegmentsChanged,
         })
       } else {
         // nothing to do
@@ -450,14 +491,13 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     segment?: TimelineSegment
     isSelected?: boolean
     onlyOneSelectedAtOnce?: boolean
-  } = {
-  }) => {
+  } = {}) => {
     const {
       invalidate,
       segments,
       selectedSegments: previousSelectedSegments,
       atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged,
-      allSegmentsChanged: previousAllSegmentsChanged
+      allSegmentsChanged: previousAllSegmentsChanged,
     } = get()
 
     // since we are un frameloop="demand" mode, we need to manual invalidate the scene
@@ -471,19 +511,15 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     })
     */
 
-    let newValue = typeof isSelected !== "boolean"
-      ? (typeof segment?.isSelected === "boolean" ? (!segment.isSelected) : false)
-      : isSelected
+    let newValue = typeof isSelected !== 'boolean' ? (typeof segment?.isSelected === 'boolean' ? !segment.isSelected : false) : isSelected
 
     // console.log('`setSelectedSegment(): new value:', newValue)
 
     // note: we do all of this in order to avoid useless state updates
     if (segment) {
-
       if (segment.isSelected === newValue) {
-
         // console.log('`setSelectedSegment(): nothing to do')
-    
+
         // nothing to do
         return
       }
@@ -492,9 +528,8 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
 
       // if needed we clear any other selected item
       if (onlyOneSelectedAtOnce) {
-
         // console.log('`setSelectedSegment(): unselecting all previous segments')
-    
+
         segments.forEach(s => {
           s.isSelected = false
         })
@@ -502,7 +537,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       }
 
       // console.log('`setSelectedSegment(): assigning new value and propagating changes:', newValue)
-    
+
       segment.isSelected = newValue
 
       if (newValue) {
@@ -515,11 +550,9 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         atLeastOneSegmentChanged: 1 + previousAtLeastOneSegmentChanged,
         allSegmentsChanged: 1 + previousAllSegmentsChanged,
       })
-
     } else {
-
       // console.log('`setSelectedSegment(): mass change requested')
-    
+
       segments.forEach(s => {
         s.isSelected = newValue
       })
@@ -556,9 +589,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
 
       const { cellWidth, containerWidth, durationInMsPerStep, setSelectedSegment, setHoveredSegment, setEditedSegment } = get()
 
-      const durationInSteps = (
-        (segment.endTimeInMs - segment.startTimeInMs) / durationInMsPerStep
-      )
+      const durationInSteps = (segment.endTimeInMs - segment.startTimeInMs) / durationInMsPerStep
 
       /*
       const startTimeInSteps = (
@@ -571,28 +602,30 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       const segmentWidth = widthInPx
 
       const isOutOfRange = offsetX < leftBarTrackScaleWidth || offsetY < topBarTimeScaleHeight
-    
-      const cursorX = pointX + (containerWidth / 2)
+
+      const cursorX = pointX + containerWidth / 2
       const cursorTimestampAtInMs = (cursorX / cellWidth) * useTimeline.getState().durationInMsPerStep
-      
+
       //console.log("cells.Cell:onClick() e:", e)
-    
+
       const wMin = cursorTimestampAtInMs - segment.startTimeInMs
       const wMax = segment.endTimeInMs - segment.startTimeInMs
       const cursorLeftPosInRatio = wMin / wMax
-    
+
       const cursorLeftPosInPx = cursorLeftPosInRatio * segmentWidth
-      const cursorRightPosInPx = segmentWidth - cursorLeftPosInPx 
-    
+      const cursorRightPosInPx = segmentWidth - cursorLeftPosInPx
+
       // note: this should be "responsive", with a max width
       const sideGrabHandleWidth = 9
       // let isInLeftArea = cursorLeftPosInRatio < 0.5
       // let isInRightArea = cursorLeftPosInRatio > 0.5
-    
+
       const area =
-        (cursorLeftPosInPx < sideGrabHandleWidth) ? SegmentArea.LEFT
-      : (cursorRightPosInPx < sideGrabHandleWidth) ? SegmentArea.RIGHT
-      : SegmentArea.MIDDLE
+        cursorLeftPosInPx < sideGrabHandleWidth
+          ? SegmentArea.LEFT
+          : cursorRightPosInPx < sideGrabHandleWidth
+            ? SegmentArea.RIGHT
+            : SegmentArea.MIDDLE
 
       if (isOutOfRange) {
         event.stopPropagation()
@@ -602,19 +635,19 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       if (eventType === SegmentPointerEvent.DOUBLE_CLICK) {
         setHoveredSegment({
           segment,
-          area
+          area,
         })
         setSelectedSegment({
           segment,
-    
+
           // we leave it unspecified to create an automated toggle
           // isSelected: true,
-    
+
           onlyOneSelectedAtOnce: true,
         })
         setEditedSegment({
           segment,
-          status: SegmentEditionStatus.EDITING
+          status: SegmentEditionStatus.EDITING,
         })
       } else if (
         eventType === SegmentPointerEvent.CLICK ||
@@ -623,28 +656,28 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       ) {
         setHoveredSegment({
           segment,
-          area
+          area,
         })
         if (area === SegmentArea.LEFT) {
           setEditedSegment({
             segment,
-            status: SegmentEditionStatus.RESIZE_START
+            status: SegmentEditionStatus.RESIZE_START,
           })
         } else if (area === SegmentArea.RIGHT) {
           setEditedSegment({
             segment,
-            status: SegmentEditionStatus.RESIZE_END
+            status: SegmentEditionStatus.RESIZE_END,
           })
         } else if (area === SegmentArea.MIDDLE) {
           setEditedSegment({
-          segment,
-            status: SegmentEditionStatus.DRAGGING
+            segment,
+            status: SegmentEditionStatus.DRAGGING,
           })
         }
       } else if (eventType === SegmentPointerEvent.UP) {
         setHoveredSegment({
           segment: undefined,
-          area
+          area,
         })
         setEditedSegment({
           segment: undefined,
@@ -660,14 +693,14 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     const { silentChangesInSegment, atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged } = get()
     set({
       silentChangesInSegment: Object.assign(silentChangesInSegment, {
-        [segmentId]: 1 + (silentChangesInSegment[segmentId] || 0)
+        [segmentId]: 1 + (silentChangesInSegment[segmentId] || 0),
       }),
       atLeastOneSegmentChanged: 1 + previousAtLeastOneSegmentChanged,
     })
   },
   trackSilentChangeInSegments: (segmentIds: string[]) => {
     const { silentChangesInSegment, atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged } = get()
-    
+
     for (const id of segmentIds) {
       silentChangesInSegment[id] = 1 + (silentChangesInSegment[id] || 0)
     }
@@ -695,7 +728,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
   setScrollX: (scrollX: number) => {
     set({ scrollX })
   },
-  handleMouseWheel: ({ deltaX, deltaY }: { deltaX: number, deltaY: number }) => {
+  handleMouseWheel: ({ deltaX, deltaY }: { deltaX: number; deltaY: number }) => {
     const { scrollX, scrollY } = get()
     // TODO: compute the limits here, to avoid doing re-renderings for nothing
     set({
@@ -704,38 +737,133 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     })
   },
   toggleTrackVisibility: (trackId: number) => {
-    const {
-      width,
-      height,
-      tracks,
-      cellWidth,
-      defaultSegmentDurationInSteps,
-      durationInMsPerStep,
-      durationInMs,
-    } = get()
+    const { width, height, tracks, cellWidth, defaultSegmentDurationInSteps, durationInMsPerStep, durationInMs } = get()
 
     set({
       ...computeContentSizeMetrics({
         width,
         height,
-        tracks: tracks.map((t: any) => (
-          t.id === trackId
-          ? { ...t, visible: !t.visible }
-          : t
-        )),
+        tracks: tracks.map((t: any) => (t.id === trackId ? { ...t, visible: !t.visible } : t)),
         cellWidth,
         defaultSegmentDurationInSteps,
         durationInMsPerStep,
         durationInMs,
-      })
+      }),
     })
+  },
+  createTrack: ({ category = ClapSegmentCategory.GENERIC, name, height }: CreateTrackParams = {}): number => {
+    const {
+      width,
+      height: projectHeight,
+      tracks,
+      cellWidth,
+      defaultCellHeight,
+      defaultPreviewHeight,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs,
+      atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged,
+      allSegmentsChanged: previousAllSegmentsChanged,
+    } = get()
+
+    const trackId = tracks.length
+    const isPreview = previewCategories.has(category)
+    const nextTracks = tracks.concat({
+      id: trackId,
+      name: name || category,
+      isPreview,
+      height: height || (isPreview ? defaultPreviewHeight : defaultCellHeight),
+      hue: 0,
+      occupied: false,
+      visible: true,
+    })
+
+    const metrics = computeContentSizeMetrics({
+      width,
+      height: projectHeight,
+      tracks: nextTracks,
+      cellWidth,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs,
+    })
+
+    set({
+      allSegmentsChanged: previousAllSegmentsChanged + 1,
+      atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged + 1,
+      ...metrics,
+    })
+
+    return trackId
+  },
+  createClip: async ({ category, track, startTimeInMs, durationInMs, label, prompt }: CreateClipParams = {}): Promise<TimelineSegment> => {
+    const { tracks, cursorTimestampAtInMs, durationInMsPerStep, defaultSegmentDurationInSteps, createTrack, addSegment } = get()
+
+    const selectedTrack = isValidNumber(track) ? track! : createTrack({ category })
+    const trackCategory = getCategoryFromTrackName(tracks[selectedTrack]?.name)
+    const clipCategory = trackCategory || category || ClapSegmentCategory.GENERIC
+    const clipStartTimeInMs = isValidNumber(startTimeInMs) ? startTimeInMs! : cursorTimestampAtInMs
+    const clipDurationInMs = isValidNumber(durationInMs) ? durationInMs! : defaultSegmentDurationInSteps * durationInMsPerStep
+    const now = new Date().toISOString()
+
+    const segment: TimelineSegment = {
+      id: createSegmentId(),
+      parentId: '',
+      childrenIds: [],
+      track: selectedTrack,
+      startTimeInMs: clipStartTimeInMs,
+      endTimeInMs: clipStartTimeInMs + clipDurationInMs,
+      category: clipCategory,
+      entityId: '',
+      workflowId: '',
+      sceneId: '',
+      startTimeInLines: 0,
+      endTimeInLines: 0,
+      prompt: prompt || '',
+      label: label || `New ${clipCategory.toLowerCase()} clip`,
+      outputType: getSegmentOutputType(clipCategory),
+      renderId: '',
+      status: ClapSegmentStatus.TO_GENERATE,
+      assetUrl: prompt || '',
+      assetDurationInMs: clipDurationInMs,
+      assetSourceType: prompt ? ClapAssetSource.PROMPT : ClapAssetSource.EMPTY,
+      assetFileFormat: '',
+      createdAt: now,
+      createdBy: 'human',
+      revision: 0,
+      editedBy: 'human',
+      outputGain: 1,
+      seed: 0,
+      visibility: SegmentVisibility.VISIBLE,
+      textures: {},
+      colors: {} as TimelineSegment['colors'],
+      isSelected: false,
+      isHovered: false,
+      isHoveredOnBody: false,
+      isHoveredOnLeftHandle: false,
+      isHoveredOnRightHandle: false,
+      isGrabbedOnBody: false,
+      isGrabbedOnLeftHandle: false,
+      isGrabbedOnRightHandle: false,
+      isActive: false,
+      isPlaying: false,
+      editionStatus: SegmentEditionStatus.EDITABLE,
+    }
+
+    await addSegment({
+      segment,
+      startTimeInMs: clipStartTimeInMs,
+      track: selectedTrack,
+    })
+
+    return segment
   },
   setContainerSize: ({ width, height }: { width: number; height: number }) => {
     const { containerWidth: previousWidth, containerHeight: previousHeight } = get()
-    const changed = 
-      (Math.round(previousWidth) !== Math.round(height))
-      || (Math.round(previousHeight) !== Math.round(height))
-    if (!changed) { return }
+    const changed = Math.round(previousWidth) !== Math.round(height) || Math.round(previousHeight) !== Math.round(height)
+    if (!changed) {
+      return
+    }
 
     set({
       containerWidth: width,
@@ -786,7 +914,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     showTargetDirPopup = false,
 
     // some extra text to append to the file name
-    extraLabel = ""
+    extraLabel = '',
   }: {
     // if embedded is true, the file will be larger, as all the content,
     // image, video, audio..
@@ -809,18 +937,18 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     const blob = await serializeClap(clap)
 
     // Create an object URL for the compressed clap blob
-    const objectUrl = URL.createObjectURL(blob);
-  
+    const objectUrl = URL.createObjectURL(blob)
+
     // Create an anchor element and force browser download
-    const anchor = document.createElement("a");
-    anchor.href = objectUrl;
-    anchor.download = saveToFilePath || `${clap.meta.title}${extraLabel}.clap`;
-    document.body.appendChild(anchor); // Append to the body (could be removed once clicked)
-    anchor.click(); // Trigger the download
-  
+    const anchor = document.createElement('a')
+    anchor.href = objectUrl
+    anchor.download = saveToFilePath || `${clap.meta.title}${extraLabel}.clap`
+    document.body.appendChild(anchor) // Append to the body (could be removed once clicked)
+    anchor.click() // Trigger the download
+
     // Cleanup: revoke the object URL and remove the anchor element
-    URL.revokeObjectURL(objectUrl);
-    document.body.removeChild(anchor);
+    URL.revokeObjectURL(objectUrl)
+    document.body.removeChild(anchor)
 
     return objectUrl.length
   },
@@ -829,14 +957,16 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
   },
   resolveSegment: async (segment: TimelineSegment): Promise<TimelineSegment> => {
     const { segmentResolver, fitSegmentToAssetDuration } = get()
-    if (!segmentResolver) { return segment }
-    
+    if (!segmentResolver) {
+      return segment
+    }
+
     segment = await segmentResolver(segment)
 
     // after a segment has ben resolved, it is possible that the size
     // of its asset changed (eg. a dialogue line longer than the segment's length)
     //
-    // there are multiple ways to solve this, one approach could be to 
+    // there are multiple ways to solve this, one approach could be to
     // just add some more B-roll (more shots)
     //
     // or we can also extend it, which is the current simple solution
@@ -857,7 +987,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
   addSegments: async ({
     segments = [],
     startTimeInMs,
-    track
+    track,
   }: {
     segments?: TimelineSegment[]
     startTimeInMs?: number
@@ -869,7 +999,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         await addSegment({
           segment,
           startTimeInMs,
-          track
+          track,
         })
       }
     }
@@ -898,24 +1028,19 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     } = get()
 
     segment.track = track
-   
+
     let nbTracks = tracks.length
 
     // add the track if it is missing
     if (!tracks[segment.track]) {
-      const isPreview =
-        segment.category === ClapSegmentCategory.IMAGE ||
-        segment.category === ClapSegmentCategory.VIDEO
-   
+      const isPreview = segment.category === ClapSegmentCategory.IMAGE || segment.category === ClapSegmentCategory.VIDEO
+
       tracks[segment.track] = {
         id: segment.track,
         // name: `Track ${s.track}`,
         name: `${segment.category}`,
         isPreview,
-        height:
-          isPreview
-          ? defaultPreviewHeight
-          : defaultCellHeight,
+        height: isPreview ? defaultPreviewHeight : defaultCellHeight,
         hue: 0,
         occupied: true,
         visible: true,
@@ -941,7 +1066,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
   addSegment: async ({
     segment,
     startTimeInMs: requestedStartTimeInMs,
-    track: requestedTrack
+    track: requestedTrack,
   }: {
     segment: TimelineSegment
     startTimeInMs?: number
@@ -965,7 +1090,6 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       assignTrack,
     } = get()
 
-
     // note: the requestedTrack might not be empty
     const segmentDuration = segment.endTimeInMs - segment.startTimeInMs
 
@@ -974,10 +1098,12 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     const endTimeInMs = startTimeInMs + segmentDuration
 
     // for now let's do something simple: to always search for an available track
-    const availableTrack = isValidNumber(requestedTrack) ? requestedTrack! : findFreeTrack({
-      startTimeInMs,
-      endTimeInMs
-    })
+    const availableTrack = isValidNumber(requestedTrack)
+      ? requestedTrack!
+      : findFreeTrack({
+          startTimeInMs,
+          endTimeInMs,
+        })
 
     /*
     console.log("availableTrack:", {
@@ -996,7 +1122,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     // also, we assume that we are adding a segment in a place where it's visible
     // (if we are wrong don't worry, our visibility detector will fix it anyway)
     segment.visibility = SegmentVisibility.VISIBLE
-    
+
     assignTrack({
       segment,
       track: availableTrack,
@@ -1005,22 +1131,18 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       triggerChange: false,
     })
 
-
     // we assume that the provided segment is valid, with a unique UUID
-  
+
     // then we need to update everything
 
     // ok so, I'm not a big fan of doing this,
     // officially the order doesn't matter in the previousSegments array
-    // this means we don't have FOR LOOPs with a BREAK etc 
+    // this means we don't have FOR LOOPs with a BREAK etc
     // still, I think we can improve our performance one day by storing them
     // on a temporally sorted tree
     const segments = previousSegments.concat(segment)
 
-    const durationInMs =
-      segment.endTimeInMs > previousDurationInMs
-      ? segment.endTimeInMs
-      : previousDurationInMs
+    const durationInMs = segment.endTimeInMs > previousDurationInMs ? segment.endTimeInMs : previousDurationInMs
 
     set({
       segments,
@@ -1035,23 +1157,16 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         defaultSegmentDurationInSteps,
         durationInMsPerStep,
         durationInMs,
-      })
+      }),
     })
   },
-  findFreeTrack: ({
-    startTimeInMs,
-    endTimeInMs
-  }: {
-    startTimeInMs?: number
-    endTimeInMs?: number
-  }): number => {
+  findFreeTrack: ({ startTimeInMs, endTimeInMs }: { startTimeInMs?: number; endTimeInMs?: number }): number => {
     const { segments } = get()
     return findFreeTrack({ segments, startTimeInMs, endTimeInMs })
   },
 
   // resize and move the end of a segment, as well as the segment after it
   fitSegmentToAssetDuration: async (segment: TimelineSegment, requestedDurationInMs?: number): Promise<void> => {
-    
     const {
       width,
       height,
@@ -1064,22 +1179,17 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       allSegmentsChanged: previousAllSegmentsChanged,
       durationInMs: previousDurationInMs,
       findFreeTrack,
-      assignTrack
+      assignTrack,
     } = get()
 
     let requestedDuration: number =
-      typeof requestedDurationInMs === "number" && isFinite(requestedDurationInMs) && !isNaN(requestedDurationInMs)
-      ? requestedDurationInMs
-      : segment.assetDurationInMs
-
+      typeof requestedDurationInMs === 'number' && isFinite(requestedDurationInMs) && !isNaN(requestedDurationInMs)
+        ? requestedDurationInMs
+        : segment.assetDurationInMs
 
     // trivial case: nothing to do!
     const segmentDurationInMs = segment.endTimeInMs - segment.startTimeInMs
-    if (
-      requestedDuration === 0
-      ||
-      segmentDurationInMs === requestedDuration
-    ) {
+    if (requestedDuration === 0 || segmentDurationInMs === requestedDuration) {
       return
     }
 
@@ -1092,14 +1202,12 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     const timeDifferenceInMs = requestedDuration - segmentDurationInMs
 
     // setup some limits
-    const newSegmentDurationInMs = Math.max(
-      minimumLengthInMs,
-      segmentDurationInMs + timeDifferenceInMs
-    )
+    const newSegmentDurationInMs = Math.max(minimumLengthInMs, segmentDurationInMs + timeDifferenceInMs)
 
     // ok, well, there is nothing to change actually
-    if (segmentDurationInMs === newSegmentDurationInMs) { return }
-
+    if (segmentDurationInMs === newSegmentDurationInMs) {
+      return
+    }
 
     // positive if new duration is longer,
     // negative if shorter
@@ -1111,9 +1219,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
 
     let durationInMs = previousDurationInMs
 
-    const referenceSegmentIsMusicOrSound =
-      segment.category === ClapSegmentCategory.MUSIC
-      || segment.category === ClapSegmentCategory.SOUND
+    const referenceSegmentIsMusicOrSound = segment.category === ClapSegmentCategory.MUSIC || segment.category === ClapSegmentCategory.SOUND
 
     let segmentsToDelete: string[] = []
 
@@ -1127,26 +1233,22 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       // 2. collision with an item on the same track (eg. of a different type)
       //    -> fix is annoying, for now the a quick solution is to put the segment
       //      onto its own free track
-      const currentSegmentIsMusicOrSound =
-        s.category === ClapSegmentCategory.MUSIC
-        || s.category === ClapSegmentCategory.SOUND
+      const currentSegmentIsMusicOrSound = s.category === ClapSegmentCategory.MUSIC || s.category === ClapSegmentCategory.SOUND
 
       const isSameCategoryAsReferenceSegment = s.category === segment.category
 
       const isSamePromptAsReferenceSegment = s.prompt === segment.prompt
 
-
       if (referenceSegmentIsMusicOrSound) {
-        
         if (isSameCategoryAsReferenceSegment && isSamePromptAsReferenceSegment) {
-          if (s.endTimeInMs <= endTimeInMs) { 
+          if (s.endTimeInMs <= endTimeInMs) {
             // we delete
-            console.log("TODO JULIAN: DELETE SEGMENT", s)
+            console.log('TODO JULIAN: DELETE SEGMENT', s)
             // segmentsToDelete.push(s.id)
-            // note: 
-          } else if (s.startTimeInMs < endTimeInMs) { 
+            // note:
+          } else if (s.startTimeInMs < endTimeInMs) {
             // we resize
-            console.log("TODO JULIAN: resize segment")
+            console.log('TODO JULIAN: resize segment')
             // s.startTimeInMs = endTimeInMs
           }
         }
@@ -1161,7 +1263,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
           if (!(s.endTimeInMs <= startTimeInMs || s.startTimeInMs >= endTimeInMs)) {
             const newTrack = findFreeTrack({ startTimeInMs, endTimeInMs })
             //console.log(`ASSIGN NEW TRACK (${newTrack}) TO SEGMENT`, s)
-     
+
             assignTrack({
               segment,
               track: newTrack,
@@ -1169,9 +1271,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
               // we don't want to trigger a state change
               triggerChange: false,
             })
-            
           }
-      
         }
       } else {
         // this is a dialogue or a video, we can apply our regular strategy
@@ -1203,16 +1303,11 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         defaultSegmentDurationInSteps,
         durationInMsPerStep,
         durationInMs,
-      })
+      }),
     })
   },
   deleteSegments: (ids: string[]): void => {
-    const {
-      segments: previousSegments,
-      allSegmentsChanged,
-      atLeastOneSegmentChanged,
-      silentChangesInSegment,
-    } = get()
+    const { segments: previousSegments, allSegmentsChanged, atLeastOneSegmentChanged, silentChangesInSegment } = get()
 
     const deletables = new Set(ids)
 
@@ -1229,12 +1324,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     })
   },
   addEntities: async (newEntities: ClapEntity[]) => {
-    const {
-      entities: previousEntities,
-      entityIndex: previousentityIndex,
-      entitiesChanged: previousEntitiesChanged,
-    } = get()
-
+    const { entities: previousEntities, entityIndex: previousentityIndex, entitiesChanged: previousEntitiesChanged } = get()
 
     let somethingChanged = false
 
@@ -1257,11 +1347,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     }
   },
   updateEntities: async (newEntities: ClapEntity[]) => {
-    const {
-      entities: previousEntities,
-      entityIndex: previousentityIndex,
-      entitiesChanged: previousEntitiesChanged,
-    } = get()
+    const { entities: previousEntities, entityIndex: previousentityIndex, entitiesChanged: previousEntitiesChanged } = get()
 
     let somethingChanged = false
     for (const newEntity of newEntities) {
@@ -1284,17 +1370,13 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       })
     }
   },
-  deleteEntities: async (entitiesToDelete: (ClapEntity|string)[]) => {
-    const {
-      entities: previousEntities,
-      entityIndex: previousentityIndex,
-      entitiesChanged: previousEntitiesChanged,
-    } = get()
+  deleteEntities: async (entitiesToDelete: (ClapEntity | string)[]) => {
+    const { entities: previousEntities, entityIndex: previousentityIndex, entitiesChanged: previousEntitiesChanged } = get()
 
     let idsToDelete: string[] = []
-  
+
     for (const newEntityOrId of entitiesToDelete) {
-      const id = typeof newEntityOrId === "string" ? newEntityOrId : newEntityOrId.id
+      const id = typeof newEntityOrId === 'string' ? newEntityOrId : newEntityOrId.id
       delete previousentityIndex[id]
       idsToDelete.push(id)
     }
@@ -1310,10 +1392,9 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
 
   setInvalidate: (invalidate?: Invalidate) => {
     set({ invalidate: invalidate || (() => {}) })
-  }
-}
-))
+  },
+}))
 
 if (typeof window !== 'undefined') {
-  (window as any).useTimeline = useTimeline
+  ;(window as any).useTimeline = useTimeline
 }

--- a/packages/timeline/src/hooks/useTimeline.ts
+++ b/packages/timeline/src/hooks/useTimeline.ts
@@ -71,6 +71,16 @@ function createSegmentId(): string {
   return `segment-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 
+let activeSegmentDrag:
+  | {
+      id: string
+      startCursorTimestampInMs: number
+      startSegmentTimeInMs: number
+      durationInMs: number
+      track: number
+    }
+  | undefined
+
 export const useTimeline = create<TimelineStore>((set, get) => ({
   ...getDefaultState(),
 
@@ -587,7 +597,22 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         }, null, 2))
       */
 
-      const { cellWidth, containerWidth, durationInMsPerStep, setSelectedSegment, setHoveredSegment, setEditedSegment } = get()
+      const {
+        cellWidth,
+        containerWidth,
+        durationInMsPerStep,
+        setSelectedSegment,
+        setHoveredSegment,
+        setEditedSegment,
+        tracks,
+        defaultCellHeight,
+        segments,
+        width,
+        height,
+        defaultSegmentDurationInSteps,
+        durationInMs: previousDurationInMs,
+        invalidate,
+      } = get()
 
       const durationInSteps = (segment.endTimeInMs - segment.startTimeInMs) / durationInMsPerStep
 
@@ -605,6 +630,72 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
 
       const cursorX = pointX + containerWidth / 2
       const cursorTimestampAtInMs = (cursorX / cellWidth) * useTimeline.getState().durationInMsPerStep
+
+      const getTrackAtPointY = (pointY: number): number | undefined => {
+        const timelineY = -pointY
+        let trackTop = 0
+
+        for (let trackIndex = 0; trackIndex < tracks.length; trackIndex++) {
+          const trackHeight = tracks[trackIndex]?.height || defaultCellHeight
+          if (timelineY >= trackTop && timelineY < trackTop + trackHeight) {
+            return trackIndex
+          }
+          trackTop += trackHeight
+        }
+
+        return undefined
+      }
+
+      const moveDraggedSegment = () => {
+        if (!activeSegmentDrag || activeSegmentDrag.id !== segment.id) {
+          return
+        }
+
+        const targetTrack = getTrackAtPointY(event.point.y) ?? activeSegmentDrag.track
+        const targetTrackCategory = getCategoryFromTrackName(tracks[targetTrack]?.name)
+
+        if (targetTrackCategory && targetTrackCategory !== segment.category) {
+          return
+        }
+
+        const rawStartTimeInMs =
+          activeSegmentDrag.startSegmentTimeInMs + cursorTimestampAtInMs - activeSegmentDrag.startCursorTimestampInMs
+        const startTimeInMs = Math.max(0, Math.round(rawStartTimeInMs / durationInMsPerStep) * durationInMsPerStep)
+        const endTimeInMs = startTimeInMs + activeSegmentDrag.durationInMs
+        const collides = segments.some(s => (
+          s.id !== segment.id &&
+          s.track === targetTrack &&
+          !(s.endTimeInMs <= startTimeInMs || s.startTimeInMs >= endTimeInMs)
+        ))
+
+        if (collides) {
+          return
+        }
+
+        segment.startTimeInMs = startTimeInMs
+        segment.endTimeInMs = endTimeInMs
+        segment.track = targetTrack
+        segment.visibility = SegmentVisibility.VISIBLE
+
+        const durationInMs = Math.max(previousDurationInMs, endTimeInMs)
+
+        set({
+          segments: [...segments],
+          durationInMs,
+          atLeastOneSegmentChanged: 1 + get().atLeastOneSegmentChanged,
+          allSegmentsChanged: 1 + get().allSegmentsChanged,
+          ...computeContentSizeMetrics({
+            width,
+            height,
+            tracks,
+            cellWidth,
+            defaultSegmentDurationInSteps,
+            durationInMsPerStep,
+            durationInMs,
+          }),
+        })
+        invalidate()
+      }
 
       //console.log("cells.Cell:onClick() e:", e)
 
@@ -673,8 +764,20 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
             segment,
             status: SegmentEditionStatus.DRAGGING,
           })
+          if (eventType === SegmentPointerEvent.DOWN) {
+            activeSegmentDrag = {
+              id: segment.id,
+              startCursorTimestampInMs: cursorTimestampAtInMs,
+              startSegmentTimeInMs: segment.startTimeInMs,
+              durationInMs: segment.endTimeInMs - segment.startTimeInMs,
+              track: segment.track,
+            }
+          } else if (eventType === SegmentPointerEvent.MOVE) {
+            moveDraggedSegment()
+          }
         }
       } else if (eventType === SegmentPointerEvent.UP) {
+        activeSegmentDrag = undefined
         setHoveredSegment({
           segment: undefined,
           area,

--- a/packages/timeline/src/types/timeline.ts
+++ b/packages/timeline/src/types/timeline.ts
@@ -1,12 +1,12 @@
-import * as THREE from "three"
-import type { ThreeEvent } from "@react-three/fiber"
-import { ClapEntity, ClapImageRatio, ClapMeta, ClapProject, ClapScene, ClapSegment, ClapTracks } from "@aitube/clap"
+import * as THREE from 'three'
+import type { ThreeEvent } from '@react-three/fiber'
+import { ClapEntity, ClapImageRatio, ClapMeta, ClapProject, ClapScene, ClapSegment, ClapSegmentCategory, ClapTracks } from '@aitube/clap'
 
-import { ClapSegmentColorScheme, ClapTimelineTheme } from "./theme"
-import { TimelineControlsImpl } from "@/components/controls/types"
-import { TimelineCameraImpl } from "@/components/camera/types"
-import { IsPlaying, JumpAt, TimelineCursorImpl, TogglePlayback } from "@/components/timeline/types"
-import { SegmentResolver } from "./rendering"
+import { ClapSegmentColorScheme, ClapTimelineTheme } from './theme'
+import { TimelineControlsImpl } from '@/components/controls/types'
+import { TimelineCameraImpl } from '@/components/camera/types'
+import { IsPlaying, JumpAt, TimelineCursorImpl, TogglePlayback } from '@/components/timeline/types'
+import { SegmentResolver } from './rendering'
 
 export type SegmentEventCallbackHandler = (e: ThreeEvent<PointerEvent> | ThreeEvent<MouseEvent>) => boolean
 
@@ -14,47 +14,46 @@ export type Invalidate = (frames?: number) => void
 
 export enum SegmentVisibility {
   // the segment is visible, and the user explicitly requested to render it before the others
-  DEMANDED = "DEMANDED",
+  DEMANDED = 'DEMANDED',
 
   // TODO: add some implicit intermediary priority options
   // such as SELECTED, HOVERED..
 
   // the segment (or at least a portion of it) is currently visible in the sliding window
-  VISIBLE = "VISIBLE",
+  VISIBLE = 'VISIBLE',
 
   // the segment is hidden, but not too far from the sliding window
-  BUFFERED = "BUFFERED",
+  BUFFERED = 'BUFFERED',
 
   // fully hidden, far from the sliding window
-  HIDDEN = "HIDDEN"
+  HIDDEN = 'HIDDEN',
 }
-
 
 export enum SegmentEditionStatus {
   // the segment is frozen and read-only and cannot be edited
   // this is useful if you want a track to be read-only
-  LOCKED = "LOCKED",
+  LOCKED = 'LOCKED',
 
   // the segment is editable and cannot be edited
-  EDITABLE = "EDITABLE",
+  EDITABLE = 'EDITABLE',
 
   // the segment is being resized
-  RESIZE_START = "RESIZE_START",
+  RESIZE_START = 'RESIZE_START',
 
   // the segment is being resized
-  RESIZE_END = "RESIZE_END",
+  RESIZE_END = 'RESIZE_END',
 
   // the segment is being dragged around
-  DRAGGING = "DRAGGING",
+  DRAGGING = 'DRAGGING',
 
   // the segment's is being edited (eg. in the edit pop-over)
-  EDITING = "EDITING",
+  EDITING = 'EDITING',
 }
 
 export enum SegmentArea {
   LEFT = 'LEFT',
   RIGHT = 'RIGHT',
-  MIDDLE = 'MIDDLE'
+  MIDDLE = 'MIDDLE',
 }
 
 export enum SegmentPointerEvent {
@@ -63,16 +62,14 @@ export enum SegmentPointerEvent {
   MOVE = 'MOVE',
   CLICK = 'CLICK',
   DOUBLE_CLICK = 'DOUBLE_CLICK',
-  RIGHT_CLICK = 'RIGHT_CLICK'
+  RIGHT_CLICK = 'RIGHT_CLICK',
 }
-
 
 // some data can only exist inside a browser session (eg. AudioBuffer)
 // or at least data that only make sense on client side
 // we could put things like a mouse hover or selected state in here
 // or simply large, recursive elements (like the scene)
 export type BrowserOnlySegmentData = {
-
   // used to give more context to the LLM, so it can have the full text of the scene
   scene?: ClapScene
 
@@ -95,10 +92,10 @@ export type BrowserOnlySegmentData = {
    * the following fields have been added to this type only very recently
    * and their implementation is not finished,
    * so they may not contain the value you wish for.
-   * 
+   *
    * please don't rely on them just yet.
-   * 
-   * Moreover they will be undefined by default, so you need 
+   *
+   * Moreover they will be undefined by default, so you need
    * const isSelected = rs.isSelected || false
    * const editionStatus = rs.editionStatus || SegmentEditionStatus.EDITABLE
    */
@@ -108,7 +105,7 @@ export type BrowserOnlySegmentData = {
   // if the segment is hovered by the mouse (anywhere)
   // note: if the mouse is pressed, this will also trigger this to TRUE
   isHovered: boolean
-  
+
   // if the segment's body is hovered by the mouse
   isHoveredOnBody: boolean
 
@@ -129,10 +126,10 @@ export type BrowserOnlySegmentData = {
 
   // if the segment is currently crossed by the timeline cursor
   isActive: boolean
-  
+
   // if the segment is currently being played
   isPlaying: boolean
-  
+
   editionStatus: SegmentEditionStatus
 }
 
@@ -194,7 +191,7 @@ export type TimelineStoreProjectState = ClapMeta & {
 
   typicalSegmentDurationInSteps: number
 
-  // note: this is a mirror value of 
+  // note: this is a mirror value of
   // it might change rapidly (many times per seconds), so use with care!
   currentZoomLevel: number
 
@@ -232,7 +229,7 @@ export type TimelineStoreProjectState = ClapMeta & {
 
 export type TimelineStorePreferencesState = {
   canvas?: HTMLCanvasElement
-  
+
   // used to track the timeline state
   // this helps informing parent app user
   // that the timeline has been recreated inside the React tree for instance
@@ -241,21 +238,21 @@ export type TimelineStorePreferencesState = {
   // container width and height
   containerWidth: number
   containerHeight: number
-  
+
   theme: ClapTimelineTheme
 
   durationInMsPerStep: number
-  
+
   /**
    * The timeline camera
-   * 
+   *
    * Note: there will be no update of this value in case the camera settings have changed
    */
   timelineCamera?: TimelineCameraImpl
 
   /**
    * The timeline controls
-   * 
+   *
    * Note: there will be no update of this value in case the controls settings have changed
    */
   timelineControls?: TimelineControlsImpl
@@ -277,6 +274,20 @@ export type TimelineStorePreferencesState = {
 
 export type TimelineStoreState = TimelineStoreProjectState & TimelineStorePreferencesState
 
+export type CreateTrackParams = {
+  category?: ClapSegmentCategory
+  name?: string
+  height?: number
+}
+
+export type CreateClipParams = {
+  category?: ClapSegmentCategory
+  track?: number
+  startTimeInMs?: number
+  durationInMs?: number
+  label?: string
+  prompt?: string
+}
 
 export type TimelineStoreModifiers = {
   setCanvas: (canvas?: HTMLCanvasElement) => void
@@ -290,29 +301,10 @@ export type TimelineStoreModifiers = {
   setVisibleSegments: (visibleSegments?: TimelineSegment[]) => void
   getCellHeight: (trackNumber?: number) => number
   getVerticalCellPosition: (start: number, end: number) => number
-  setHoveredSegment: (params?: {
-    segment?: TimelineSegment
-    area?: SegmentArea 
-  }) => void
-  setEditedSegment: ({
-    segment,
-    status
-  }: {
-    segment?: TimelineSegment
-    status?: SegmentEditionStatus
-  }) => void
-  setSelectedSegment: (params?: {
-    segment?: TimelineSegment
-    isSelected?: boolean
-    onlyOneSelectedAtOnce?: boolean
-  }) => void
-  handleSegmentEvent: ({
-    eventType,
-    segment,
-  }: {
-    eventType: SegmentPointerEvent
-    segment: TimelineSegment
-  }) => SegmentEventCallbackHandler
+  setHoveredSegment: (params?: { segment?: TimelineSegment; area?: SegmentArea }) => void
+  setEditedSegment: ({ segment, status }: { segment?: TimelineSegment; status?: SegmentEditionStatus }) => void
+  setSelectedSegment: (params?: { segment?: TimelineSegment; isSelected?: boolean; onlyOneSelectedAtOnce?: boolean }) => void
+  handleSegmentEvent: ({ eventType, segment }: { eventType: SegmentPointerEvent; segment: TimelineSegment }) => SegmentEventCallbackHandler
 
   // the purpose of those functions is to allow an external component
   // to modify the segments in-line, and then trigger a redraw
@@ -327,6 +319,8 @@ export type TimelineStoreModifiers = {
   setScrollX: (scrollX: number) => void
   handleMouseWheel: ({ deltaX, deltaY }: { deltaX: number; deltaY: number }) => void
   toggleTrackVisibility: (trackId: number) => void
+  createTrack: (params?: CreateTrackParams) => number
+  createClip: (params?: CreateClipParams) => Promise<TimelineSegment>
   setContainerSize: ({ width, height }: { width: number; height: number }) => void
   setTimelineCursor: (timelineCursor?: TimelineCursorImpl) => void
   setIsDraggingCursor: (isDraggingCursor: boolean) => void
@@ -360,46 +354,29 @@ export type TimelineStoreModifiers = {
     startTimeInMs?: number
     track?: number
   }) => Promise<void>
-  assignTrack: ({
-    segment,
-    track,
-    triggerChange,
-  }: {
-    segment: TimelineSegment
-    track: number
-    triggerChange?: boolean
-  }) => Promise<void>
-  addSegment: ({
-    segment,
-    startTimeInMs,
-    track,
-  }: {
-    segment: TimelineSegment
-    startTimeInMs?: number
-    track?: number
-}) => Promise<void>
+  assignTrack: ({ segment, track, triggerChange }: { segment: TimelineSegment; track: number; triggerChange?: boolean }) => Promise<void>
+  addSegment: ({ segment, startTimeInMs, track }: { segment: TimelineSegment; startTimeInMs?: number; track?: number }) => Promise<void>
 
   /**
    * Find an available free track
-   * 
-   * @param params 
-   * @returns 
+   *
+   * @param params
+   * @returns
    */
   findFreeTrack: (params: { startTimeInMs?: number; endTimeInMs?: number }) => number
-
 
   fitSegmentToAssetDuration: (segment: TimelineSegment, durationInMs?: number) => Promise<void>
 
   /**
-   * Delete segments from the 
-   * @param ids 
-   * @returns 
+   * Delete segments from the
+   * @param ids
+   * @returns
    */
   deleteSegments: (ids: string[]) => void
 
   addEntities: (entities: ClapEntity[]) => Promise<void>
   updateEntities: (entities: ClapEntity[]) => Promise<void>
-  deleteEntities: (entities: (ClapEntity|string)[]) => Promise<void>
+  deleteEntities: (entities: (ClapEntity | string)[]) => Promise<void>
 
   setInvalidate: (invalidate?: Invalidate) => void
 }


### PR DESCRIPTION
## Summary

- Adds timeline store actions for creating typed tracks and clips.
- Adds a small timeline overlay with a track-type selector, target-track selector, and buttons to add tracks/clips.
- Creates new clips at the current timeline cursor with valid Clap segment defaults.
- Enables clip dragging on the timeline with step snapping, zero-time clamping, collision rejection, and compatible cross-track moves.

## Details

This is a focused first pass for issue #10. It enables dynamic track creation and dynamic clip creation from the editor UI:

- New tracks can be created with a selected Clap segment category.
- New clips can be created on a new track or an existing visible track.
- Clips created on an existing track use the track category as the source of truth.
- Timeline metrics are recalculated after track/clip creation and clip drag moves.
- Dragging a clip horizontally preserves its duration and clamps it at time zero.
- Dragging a clip onto another track is accepted only when that track has the same category.
- Drag moves are rejected when they would collide with another clip on the target track.

## Verification

- `git diff --check` passes.
- Local Bun runtime found at `.tools/bun/bin/bun.exe`.
- `bun build packages/timeline/src/index.tsx --outfile=packages/timeline/dist/index.js ...` passes.
- Timeline declaration emission passes when invoking TypeScript directly through bundled Node:
  `node ./node_modules/typescript/lib/tsc.js --emitDeclarationOnly --project packages/timeline/tsconfig.types.json`
- `bun build packages/app/src/components/core/timeline/index.tsx --outfile=.tools/timeline-component-check.js ...` passes.

## Patch

Public patch link: https://paste.rs/dMU4V

## Related issue

Closes #10
