### PR TITLE
feat: add timeline track and clip creation APIs

### DIFF
--- a/packages/clap/index.ts
+++ b/packages/clap/index.ts
@@ -1,0 +1,1 @@
+export * from "./src"

--- a/packages/clap/src/index.ts
+++ b/packages/clap/src/index.ts
@@ -1,5 +1,18 @@
 export {
   ClapAssetSource,
+  ClapFormat,
+  ClapImageRatio,
+  ClapOutputType,
+  ClapSegmentCategory,
+  ClapSegmentFilteringMode,
+  ClapSegmentStatus,
+  ClapCompletionMode,
+  ClapInputCategory,
+  ClapWorkflowEngine,
+  ClapWorkflowCategory,
+  ClapWorkflowProvider
+} from '@/types'
+export type {
   ClapAuthor,
   ClapEntity,
   ClapEntityAppearance,
@@ -8,23 +21,15 @@ export {
   ClapEntityGender,
   ClapEntityRegion,
   ClapEntityTimbre,
-  ClapFormat,
   ClapHeader,
-  ClapImageRatio,
   ClapMeta,
-  ClapOutputType,
   ClapProject,
   ClapScene,
   ClapSceneEvent,
   ClapSegment,
-  ClapSegmentCategory,
-  ClapSegmentFilteringMode,
-  ClapSegmentStatus,
   ClapTrack,
   ClapTracks,
   ClapVoice,
-  ClapCompletionMode,
-  ClapInputCategory,
   ClapInputField,
   ClapInputFieldNumber,
   ClapInputFieldInteger,
@@ -34,9 +39,6 @@ export {
   ClapInputFields,
   ClapInputValue,
   ClapInputValues,
-  ClapWorkflowEngine,
-  ClapWorkflowCategory,
-  ClapWorkflowProvider,
   ClapWorkflow
 } from '@/types'
 export {

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -15,6 +15,7 @@
     "publish": "npm publish --access public",
     "update": "rm -Rf node_modules && rm bun.lockb && bun i && bun run build",
     "dev": "vite",
+    "test": "bun test",
     "serve": "vite preview"
   },
   "devDependencies": {

--- a/packages/timeline/src/components/timeline/LeftBarTrackScale.tsx
+++ b/packages/timeline/src/components/timeline/LeftBarTrackScale.tsx
@@ -32,6 +32,7 @@ export function LeftBarTrackScale() {
   const getVerticalCellPosition = useTimeline((s) => s.getVerticalCellPosition)
 
   const tracks = useTimeline(s => s.tracks)
+  const createTrack = useTimeline((s) => s.createTrack)
   const toggleTrackVisibility = useTimeline((s) => s.toggleTrackVisibility)
   const setTrackCategory = useTimeline((s) => s.setTrackCategory)
 
@@ -64,6 +65,38 @@ export function LeftBarTrackScale() {
       ))}
       </group>
       <group position={[0, 0, 0]}>
+        <Html
+          position={[
+            leftBarTrackScaleWidth / 2,
+            18,
+            4
+          ]}
+          center
+        >
+          <button
+            aria-label="Create track"
+            title="Create track"
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              createTrack({ category: ClapSegmentCategory.GENERIC })
+              event.stopPropagation()
+            }}
+            style={{
+              width: 76,
+              height: 20,
+              border: "1px solid rgba(255,255,255,0.35)",
+              borderRadius: 4,
+              background: "rgba(0,0,0,0.45)",
+              color: theme.leftBarTrackScale.textColor,
+              fontSize: 13,
+              fontWeight: 700,
+              lineHeight: "18px",
+              cursor: "pointer",
+            }}
+          >
+            +
+          </button>
+        </Html>
         {tracks.map(track => (
           <Plane
           key={track.id}

--- a/packages/timeline/src/components/timeline/LeftBarTrackScale.tsx
+++ b/packages/timeline/src/components/timeline/LeftBarTrackScale.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { Plane, Text } from "@react-three/drei"
+import { Html, Plane, Text } from "@react-three/drei"
+import { ClapSegmentCategory } from "@aitube/clap"
 
 import {
 useTimeline
@@ -9,6 +10,16 @@ import { leftBarTrackScaleWidth } from "@/constants/themes"
 import { useHorizontaTrackLines } from "@/hooks/useHorizontalTrackLines"
 import { LineGeometry } from "three/examples/jsm/Addons.js"
 import { hslToHex } from "@/utils"
+
+const editableTrackCategories = [
+  ClapSegmentCategory.GENERIC,
+  ClapSegmentCategory.IMAGE,
+  ClapSegmentCategory.VIDEO,
+  ClapSegmentCategory.DIALOGUE,
+  ClapSegmentCategory.SOUND,
+  ClapSegmentCategory.MUSIC,
+  ClapSegmentCategory.ACTION,
+]
 
 export function LeftBarTrackScale() {
   // console.log(`re-rendering <LeftBarTrackScale>`)
@@ -22,6 +33,7 @@ export function LeftBarTrackScale() {
 
   const tracks = useTimeline(s => s.tracks)
   const toggleTrackVisibility = useTimeline((s) => s.toggleTrackVisibility)
+  const setTrackCategory = useTimeline((s) => s.setTrackCategory)
 
   const setLeftBarTrackScale = useTimeline(s => s.setLeftBarTrackScale)
 
@@ -135,39 +147,48 @@ export function LeftBarTrackScale() {
             track.id
             }
           </Text>
-          <Text
-            
+          <Html
             position={[
               10,
-              -8, // -getVerticalCellPosition(0, track.id),
-              2
+              -8,
+              3
             ]}
-
-            scale={[
-              11,
-              11,
-              1
-            ]}
-
-            lineHeight={1.0}
-            color={theme.leftBarTrackScale.textColor}
-            // fillOpacity={0.7}
-            anchorX="center" // default
-            anchorY="middle" // default
-
-            // keep in mind this will impact the font width
-            // so you will have to change the "Arial" or "bold Arial"
-            // in the function which computes a character's width
-            fontWeight={600}
-            fillOpacity={0.7}
-            visible={
-              true
-            }
+            center
           >
-            {
-            track.name
-            }
-          </Text>
+            <select
+              aria-label={`Track ${track.id} type`}
+              value={
+                editableTrackCategories.includes(track.name as ClapSegmentCategory)
+                  ? track.name
+                  : ClapSegmentCategory.GENERIC
+              }
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={(event) => event.stopPropagation()}
+              onChange={(event) => {
+                setTrackCategory({
+                  trackId: track.id,
+                  category: event.currentTarget.value as ClapSegmentCategory,
+                })
+                event.stopPropagation()
+              }}
+              style={{
+                width: 76,
+                maxWidth: 76,
+                height: 18,
+                border: "1px solid rgba(255,255,255,0.35)",
+                borderRadius: 4,
+                background: "rgba(0,0,0,0.35)",
+                color: theme.leftBarTrackScale.textColor,
+                fontSize: 10,
+              }}
+            >
+              {editableTrackCategories.map((category) => (
+                <option key={category} value={category}>
+                  {category}
+                </option>
+              ))}
+            </select>
+          </Html>
           </Plane>
         ))}
       </group>

--- a/packages/timeline/src/components/timeline/Timeline.tsx
+++ b/packages/timeline/src/components/timeline/Timeline.tsx
@@ -1,6 +1,7 @@
 import { Plane } from "@react-three/drei"
 import { useThree } from "@react-three/fiber"
 import { useEffect } from "react"
+import { ClapSegmentCategory } from "@aitube/clap"
 
 import {
   useTimeline
@@ -11,6 +12,8 @@ import { Cursor } from "./Cursor"
 import { Grid } from "./Grid"
 import { LeftBarTrackScale } from "./LeftBarTrackScale"
 import { TopBarTimeScale } from "./TopBarTimeScale"
+
+const trackCategoryValues = Object.values(ClapSegmentCategory)
 
 export function Timeline({ width, height }: { width: number; height: number }) {
   const { size } = useThree()
@@ -25,6 +28,9 @@ export function Timeline({ width, height }: { width: number; height: number }) {
   const cellWidth = useTimeline(s => s.cellWidth)
   const durationInMsPerStep = useTimeline(s => s.durationInMsPerStep)
   const createClip = useTimeline(s => s.createClip)
+  const tracks = useTimeline(s => s.tracks)
+  const getCellHeight = useTimeline(s => s.getCellHeight)
+  const getVerticalCellPosition = useTimeline(s => s.getVerticalCellPosition)
 
   // console.log(`re-rendering <Timeline>`)
   return (
@@ -43,7 +49,21 @@ export function Timeline({ width, height }: { width: number; height: number }) {
           if (!cellWidth || !durationInMsPerStep) { return }
           const cursorX = event.point.x + (width / 2)
           const startTimeInMs = Math.max(0, (cursorX / cellWidth) * durationInMsPerStep)
-          void createClip({ startTimeInMs })
+          const cursorY = Math.max(0, (contentHeight / 2) - event.point.y)
+          const targetTrack = tracks.find((track) => {
+            const top = getVerticalCellPosition(0, track.id)
+            const bottom = top + getCellHeight(track.id)
+            return cursorY >= top && cursorY < bottom
+          })
+          const trackCategory = targetTrack?.name as ClapSegmentCategory | undefined
+          const category = trackCategory && trackCategoryValues.includes(trackCategory)
+            ? trackCategory
+            : ClapSegmentCategory.GENERIC
+          void createClip({
+            startTimeInMs,
+            track: targetTrack?.id,
+            category,
+          })
         }}>
         <meshBasicMaterial
           attach="material"

--- a/packages/timeline/src/components/timeline/Timeline.tsx
+++ b/packages/timeline/src/components/timeline/Timeline.tsx
@@ -22,6 +22,9 @@ export function Timeline({ width, height }: { width: number; height: number }) {
 
   const contentHeight = useTimeline(s => s.contentHeight)
   const contentWidth = useTimeline(s => s.contentWidth)
+  const cellWidth = useTimeline(s => s.cellWidth)
+  const durationInMsPerStep = useTimeline(s => s.durationInMsPerStep)
+  const createClip = useTimeline(s => s.createClip)
 
   // console.log(`re-rendering <Timeline>`)
   return (
@@ -34,7 +37,14 @@ export function Timeline({ width, height }: { width: number; height: number }) {
           -(size.width / 2),
           0,
           -1
-        ]}>
+        ]}
+        onDoubleClick={(event) => {
+          event.stopPropagation()
+          if (!cellWidth || !durationInMsPerStep) { return }
+          const cursorX = event.point.x + (width / 2)
+          const startTimeInMs = Math.max(0, (cursorX / cellWidth) * durationInMsPerStep)
+          void createClip({ startTimeInMs })
+        }}>
         <meshBasicMaterial
           attach="material"
           transparent

--- a/packages/timeline/src/hooks/useTimeline.ts
+++ b/packages/timeline/src/hooks/useTimeline.ts
@@ -539,6 +539,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
   }): SegmentEventCallbackHandler => {
     function segmentEventCallbackHandler(event: ThreeEvent<PointerEvent> | ThreeEvent<MouseEvent>) {
       const pointX = event.point.x
+      const pointY = event.point.y
       const offsetX = event.offsetX
       const offsetY = event.offsetY
 
@@ -554,7 +555,20 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         }, null, 2))
       */
 
-      const { cellWidth, containerWidth, durationInMsPerStep, setSelectedSegment, setHoveredSegment, setEditedSegment } = get()
+      const {
+        cellWidth,
+        containerWidth,
+        contentHeight,
+        durationInMsPerStep,
+        tracks,
+        editedSegment,
+        getCellHeight,
+        getVerticalCellPosition,
+        moveClip,
+        setSelectedSegment,
+        setHoveredSegment,
+        setEditedSegment,
+      } = get()
 
       const durationInSteps = (
         (segment.endTimeInMs - segment.startTimeInMs) / durationInMsPerStep
@@ -595,6 +609,29 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       : SegmentArea.MIDDLE
 
       if (isOutOfRange) {
+        event.stopPropagation()
+        return false
+      }
+
+      const isPrimaryButtonDown = event.buttons === 1
+      if (
+        eventType === SegmentPointerEvent.MOVE
+        && area === SegmentArea.MIDDLE
+        && isPrimaryButtonDown
+        && editedSegment?.id === segment.id
+        && editedSegment.editionStatus === SegmentEditionStatus.DRAGGING
+      ) {
+        const cursorY = Math.max(0, (contentHeight / 2) - pointY)
+        const targetTrack = tracks.find((track) => {
+          const top = getVerticalCellPosition(0, track.id)
+          const bottom = top + getCellHeight(track.id)
+          return cursorY >= top && cursorY < bottom
+        })
+        moveClip({
+          segmentId: segment.id,
+          startTimeInMs: cursorTimestampAtInMs - ((segment.endTimeInMs - segment.startTimeInMs) / 2),
+          track: targetTrack?.id,
+        })
         event.stopPropagation()
         return false
       }
@@ -730,6 +767,65 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       })
     })
   },
+  setTrackCategory: ({
+    trackId,
+    category,
+  }: {
+    trackId: number
+    category: ClapSegmentCategory
+  }): boolean => {
+    const {
+      width,
+      height,
+      tracks,
+      segments,
+      cellWidth,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs,
+      defaultCellHeight,
+      defaultPreviewHeight,
+      allSegmentsChanged: previousAllSegmentsChanged,
+      atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged,
+    } = get()
+
+    const track = tracks[trackId]
+    if (!track) { return false }
+
+    const hasConflictingSegments = segments.some((segment) => (
+      segment.track === trackId
+      && segment.category !== category
+    ))
+    if (hasConflictingSegments) { return false }
+
+    const isPreview = category === ClapSegmentCategory.IMAGE || category === ClapSegmentCategory.VIDEO
+    const nextTracks = tracks.map((track) => (
+      track.id === trackId
+        ? {
+          ...track,
+          name: `${category}`,
+          isPreview,
+          height: isPreview ? defaultPreviewHeight : defaultCellHeight,
+        }
+        : track
+    ))
+
+    set({
+      allSegmentsChanged: previousAllSegmentsChanged + 1,
+      atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged + 1,
+      ...computeContentSizeMetrics({
+        width,
+        height,
+        tracks: nextTracks,
+        cellWidth,
+        defaultSegmentDurationInSteps,
+        durationInMsPerStep,
+        durationInMs,
+      }),
+    })
+
+    return true
+  },
   createTrack: ({
     trackId,
     name,
@@ -839,7 +935,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
   setContainerSize: ({ width, height }: { width: number; height: number }) => {
     const { containerWidth: previousWidth, containerHeight: previousHeight } = get()
     const changed = 
-      (Math.round(previousWidth) !== Math.round(height))
+      (Math.round(previousWidth) !== Math.round(width))
       || (Math.round(previousHeight) !== Math.round(height))
     if (!changed) { return }
 
@@ -1223,6 +1319,102 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
     })
 
     return clip
+  },
+  moveClip: ({
+    segmentId,
+    startTimeInMs,
+    track,
+  }: {
+    segmentId: string
+    startTimeInMs?: number
+    track?: number
+  }): TimelineSegment | undefined => {
+    const {
+      width,
+      height,
+      tracks,
+      segments: previousSegments,
+      cellWidth,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs: previousDurationInMs,
+      allSegmentsChanged: previousAllSegmentsChanged,
+      atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged,
+    } = get()
+
+    const segment = previousSegments.find((segment) => segment.id === segmentId)
+    if (!segment) { return undefined }
+
+    const segmentDurationInMs = segment.endTimeInMs - segment.startTimeInMs
+    const nextStartTimeInMs = isValidNumber(startTimeInMs)
+      ? Math.max(0, startTimeInMs!)
+      : segment.startTimeInMs
+    const nextEndTimeInMs = nextStartTimeInMs + segmentDurationInMs
+    const nextTrackId = isValidNumber(track) ? track! : segment.track
+    const targetTrack = tracks[nextTrackId]
+    if (!targetTrack) { return undefined }
+
+    const targetCategories = targetTrack.name.split(",").map((name) => name.trim())
+    const acceptsCategory =
+      targetTrack.name === "(empty)"
+      || targetCategories.includes(segment.category)
+    if (!acceptsCategory) { return undefined }
+
+    const hasCollision = previousSegments.some((otherSegment) => (
+      otherSegment.id !== segment.id
+      && otherSegment.track === nextTrackId
+      && otherSegment.startTimeInMs < nextEndTimeInMs
+      && otherSegment.endTimeInMs > nextStartTimeInMs
+    ))
+    if (hasCollision) { return undefined }
+
+    let movedSegment: TimelineSegment | undefined
+    const segments = previousSegments.map((previousSegment) => {
+      if (previousSegment.id !== segment.id) { return previousSegment }
+
+      movedSegment = {
+        ...previousSegment,
+        startTimeInMs: nextStartTimeInMs,
+        endTimeInMs: nextEndTimeInMs,
+        track: nextTrackId,
+      }
+      return movedSegment
+    })
+
+    const tracksWithOccupancy = tracks.map((track) => {
+      const occupied = segments.some((segment) => segment.track === track.id)
+      if (track.id !== nextTrackId) {
+        return { ...track, occupied }
+      }
+
+      return {
+        ...track,
+        name: track.name === "(empty)" ? `${segment.category}` : track.name,
+        occupied,
+      }
+    })
+
+    const durationInMs = nextEndTimeInMs > previousDurationInMs
+      ? nextEndTimeInMs
+      : previousDurationInMs
+
+    set({
+      segments,
+      allSegmentsChanged: previousAllSegmentsChanged + 1,
+      atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged + 1,
+      durationInMs,
+      ...computeContentSizeMetrics({
+        width,
+        height,
+        tracks: tracksWithOccupancy,
+        cellWidth,
+        defaultSegmentDurationInSteps,
+        durationInMsPerStep,
+        durationInMs,
+      }),
+    })
+
+    return movedSegment
   },
   findFreeTrack: ({
     startTimeInMs,

--- a/packages/timeline/src/hooks/useTimeline.ts
+++ b/packages/timeline/src/hooks/useTimeline.ts
@@ -562,6 +562,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         durationInMsPerStep,
         tracks,
         editedSegment,
+        segmentDragOffsetInMs,
         getCellHeight,
         getVerticalCellPosition,
         moveClip,
@@ -616,7 +617,6 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       const isPrimaryButtonDown = event.buttons === 1
       if (
         eventType === SegmentPointerEvent.MOVE
-        && area === SegmentArea.MIDDLE
         && isPrimaryButtonDown
         && editedSegment?.id === segment.id
         && editedSegment.editionStatus === SegmentEditionStatus.DRAGGING
@@ -629,7 +629,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         })
         moveClip({
           segmentId: segment.id,
-          startTimeInMs: cursorTimestampAtInMs - ((segment.endTimeInMs - segment.startTimeInMs) / 2),
+          startTimeInMs: cursorTimestampAtInMs - segmentDragOffsetInMs,
           track: targetTrack?.id,
         })
         event.stopPropagation()
@@ -673,8 +673,14 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
             status: SegmentEditionStatus.RESIZE_END
           })
         } else if (area === SegmentArea.MIDDLE) {
+          if (eventType === SegmentPointerEvent.DOWN) {
+            set({
+              segmentDragOffsetInMs: Math.max(0, Math.min(wMin, wMax)),
+            })
+            ;(event.target as any)?.setPointerCapture?.((event as any).pointerId)
+          }
           setEditedSegment({
-          segment,
+            segment,
             status: SegmentEditionStatus.DRAGGING
           })
         }
@@ -686,6 +692,8 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         setEditedSegment({
           segment: undefined,
         })
+        set({ segmentDragOffsetInMs: 0 })
+        ;(event.target as any)?.releasePointerCapture?.((event as any).pointerId)
       }
 
       event.stopPropagation()

--- a/packages/timeline/src/hooks/useTimeline.ts
+++ b/packages/timeline/src/hooks/useTimeline.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand"
 import * as THREE from "three"
 import type { ThreeEvent } from "@react-three/fiber"
-import { ClapProject, ClapSegment, ClapSegmentCategory, isValidNumber, newClap, serializeClap, ClapTracks, ClapEntity, ClapMeta } from "@aitube/clap"
+import { ClapProject, ClapSegment, ClapSegmentCategory, isValidNumber, newClap, newSegment, serializeClap, ClapTracks, ClapEntity, ClapMeta } from "@aitube/clap"
 
 import { TimelineSegment, SegmentEditionStatus, SegmentVisibility, TimelineStore, SegmentArea, SegmentPointerEvent, SegmentEventCallbackHandler, Invalidate } from "@/types/timeline"
 import { getDefaultProjectState, getDefaultState } from "@/utils/getDefaultState"
@@ -730,6 +730,112 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       })
     })
   },
+  createTrack: ({
+    trackId,
+    name,
+    category,
+    height,
+    isPreview,
+  }: {
+    trackId?: number
+    name?: string
+    category?: ClapSegmentCategory
+    height?: number
+    isPreview?: boolean
+  } = {}): number => {
+    const {
+      width,
+      height: timelineHeight,
+      tracks,
+      cellWidth,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs,
+      defaultCellHeight,
+      defaultPreviewHeight,
+      allSegmentsChanged: previousAllSegmentsChanged,
+      atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged,
+    } = get()
+
+    const nextTrackId = isValidNumber(trackId)
+      ? trackId!
+      : tracks.reduce((maxId, track) => Math.max(maxId, track?.id ?? -1), -1) + 1
+
+    const isPreviewTrack = typeof isPreview === "boolean"
+      ? isPreview
+      : category === ClapSegmentCategory.IMAGE || category === ClapSegmentCategory.VIDEO
+
+    const nextTracks = tracks.slice()
+    for (let id = 0; id < nextTrackId; id++) {
+      if (!nextTracks[id]) {
+        nextTracks[id] = {
+          id,
+          name: "(empty)",
+          isPreview: false,
+          height: defaultCellHeight,
+          hue: 0,
+          occupied: false,
+          visible: true,
+        }
+      }
+    }
+    nextTracks[nextTrackId] = {
+      id: nextTrackId,
+      name: name || (category ? `${category}` : "(empty)"),
+      isPreview: isPreviewTrack,
+      height: isValidNumber(height)
+        ? height!
+        : isPreviewTrack
+          ? defaultPreviewHeight
+          : defaultCellHeight,
+      hue: 0,
+      occupied: false,
+      visible: true,
+    }
+
+    set({
+      allSegmentsChanged: previousAllSegmentsChanged + 1,
+      atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged + 1,
+      ...computeContentSizeMetrics({
+        width,
+        height: timelineHeight,
+        tracks: nextTracks,
+        cellWidth,
+        defaultSegmentDurationInSteps,
+        durationInMsPerStep,
+        durationInMs,
+      }),
+    })
+
+    return nextTrackId
+  },
+  findTrackForClip: ({
+    category,
+    startTimeInMs = 0,
+    endTimeInMs = startTimeInMs,
+  }: {
+    category?: ClapSegmentCategory
+    startTimeInMs?: number
+    endTimeInMs?: number
+  } = {}): number | undefined => {
+    if (!category) { return undefined }
+
+    const { tracks, segments } = get()
+
+    return tracks.find((track) => {
+      if (!track?.visible) { return false }
+
+      const categories = track.name.split(",").map((name) => name.trim())
+      const acceptsCategory = categories.includes(category) || track.name === "(empty)"
+      if (!acceptsCategory) { return false }
+
+      return !segments.some((segment) => (
+        segment.track === track.id
+        && segment.startTimeInMs < endTimeInMs
+        && segment.endTimeInMs > startTimeInMs
+      ))
+    })?.id
+  },
   setContainerSize: ({ width, height }: { width: number; height: number }) => {
     const { containerWidth: previousWidth, containerHeight: previousHeight } = get()
     const changed = 
@@ -920,6 +1026,19 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         occupied: true,
         visible: true,
       }
+    } else {
+      const track = tracks[segment.track]
+      const categories = track.name.split(",").map((name) => name.trim())
+      const isEmptyTrack = track.name === "(empty)"
+      tracks[segment.track] = {
+        ...track,
+        name: isEmptyTrack
+          ? `${segment.category}`
+          : categories.includes(segment.category)
+            ? track.name
+            : "(misc)",
+        occupied: true,
+      }
     }
 
     if (triggerChange) {
@@ -1037,6 +1156,73 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         durationInMs,
       })
     })
+  },
+  createClip: async ({
+    category = ClapSegmentCategory.GENERIC,
+    startTimeInMs = 0,
+    durationInMs,
+    track,
+    label,
+    prompt,
+  }: {
+    category?: ClapSegmentCategory
+    startTimeInMs?: number
+    durationInMs?: number
+    track?: number
+    label?: string
+    prompt?: string
+  } = {}): Promise<TimelineSegment> => {
+    const {
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      createTrack,
+      findTrackForClip,
+      addSegment,
+      tracks,
+    } = get()
+
+    const assetDurationInMs = isValidNumber(durationInMs)
+      ? durationInMs!
+      : defaultSegmentDurationInSteps * durationInMsPerStep
+
+    const endTimeInMs = startTimeInMs + assetDurationInMs
+    const shouldUseRequestedTrack = isValidNumber(track)
+    const matchingTrack = shouldUseRequestedTrack
+      ? undefined
+      : findTrackForClip({
+        category,
+        startTimeInMs,
+        endTimeInMs,
+      })
+    const targetTrack = shouldUseRequestedTrack
+      ? track!
+      : isValidNumber(matchingTrack)
+        ? matchingTrack!
+        : createTrack({ category })
+
+    if (shouldUseRequestedTrack && !tracks[targetTrack]) {
+      createTrack({ trackId: targetTrack, category })
+    }
+
+    const clip = await clapSegmentToTimelineSegment(newSegment({
+      category,
+      track: targetTrack,
+      startTimeInMs,
+      endTimeInMs,
+      assetDurationInMs,
+      label,
+      prompt,
+      createdBy: "human",
+      editedBy: "human",
+    }))
+
+    await addSegment({
+      segment: clip,
+      startTimeInMs,
+      track: targetTrack,
+    })
+
+    return clip
   },
   findFreeTrack: ({
     startTimeInMs,

--- a/packages/timeline/src/types/timeline.ts
+++ b/packages/timeline/src/types/timeline.ts
@@ -202,6 +202,7 @@ export type TimelineStoreProjectState = ClapMeta & {
   // is both present inside each segment and also aliased here, for fast access
   hoveredSegment?: TimelineSegment
   editedSegment?: TimelineSegment
+  segmentDragOffsetInMs: number
   selectedSegments: TimelineSegment[]
 
   allSegmentsChanged: number

--- a/packages/timeline/src/types/timeline.ts
+++ b/packages/timeline/src/types/timeline.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three"
 import type { ThreeEvent } from "@react-three/fiber"
-import { ClapEntity, ClapImageRatio, ClapMeta, ClapProject, ClapScene, ClapSegment, ClapTracks } from "@aitube/clap"
+import { ClapEntity, ClapImageRatio, ClapMeta, ClapProject, ClapScene, ClapSegment, ClapSegmentCategory, ClapTracks } from "@aitube/clap"
 
 import { ClapSegmentColorScheme, ClapTimelineTheme } from "./theme"
 import { TimelineControlsImpl } from "@/components/controls/types"
@@ -327,6 +327,18 @@ export type TimelineStoreModifiers = {
   setScrollX: (scrollX: number) => void
   handleMouseWheel: ({ deltaX, deltaY }: { deltaX: number; deltaY: number }) => void
   toggleTrackVisibility: (trackId: number) => void
+  createTrack: (params?: {
+    trackId?: number
+    name?: string
+    category?: ClapSegmentCategory
+    height?: number
+    isPreview?: boolean
+  }) => number
+  findTrackForClip: (params?: {
+    category?: ClapSegmentCategory
+    startTimeInMs?: number
+    endTimeInMs?: number
+  }) => number | undefined
   setContainerSize: ({ width, height }: { width: number; height: number }) => void
   setTimelineCursor: (timelineCursor?: TimelineCursorImpl) => void
   setIsDraggingCursor: (isDraggingCursor: boolean) => void
@@ -365,7 +377,7 @@ export type TimelineStoreModifiers = {
     track,
     triggerChange,
   }: {
-    segment: TimelineSegment
+    segment: ClapSegment
     track: number
     triggerChange?: boolean
   }) => Promise<void>
@@ -378,6 +390,14 @@ export type TimelineStoreModifiers = {
     startTimeInMs?: number
     track?: number
 }) => Promise<void>
+  createClip: (params?: {
+    category?: ClapSegmentCategory
+    startTimeInMs?: number
+    durationInMs?: number
+    track?: number
+    label?: string
+    prompt?: string
+  }) => Promise<TimelineSegment>
 
   /**
    * Find an available free track

--- a/packages/timeline/src/types/timeline.ts
+++ b/packages/timeline/src/types/timeline.ts
@@ -327,6 +327,10 @@ export type TimelineStoreModifiers = {
   setScrollX: (scrollX: number) => void
   handleMouseWheel: ({ deltaX, deltaY }: { deltaX: number; deltaY: number }) => void
   toggleTrackVisibility: (trackId: number) => void
+  setTrackCategory: (params: {
+    trackId: number
+    category: ClapSegmentCategory
+  }) => boolean
   createTrack: (params?: {
     trackId?: number
     name?: string
@@ -398,6 +402,11 @@ export type TimelineStoreModifiers = {
     label?: string
     prompt?: string
   }) => Promise<TimelineSegment>
+  moveClip: (params: {
+    segmentId: string
+    startTimeInMs?: number
+    track?: number
+  }) => TimelineSegment | undefined
 
   /**
    * Find an available free track

--- a/packages/timeline/src/utils/getDefaultState.ts
+++ b/packages/timeline/src/utils/getDefaultState.ts
@@ -49,6 +49,7 @@ export function getDefaultProjectState(): TimelineStoreProjectState {
     // is both present inside each segment and also aliased here, for fast access
     hoveredSegment: undefined,
     editedSegment: undefined,
+    segmentDragOffsetInMs: 0,
     selectedSegments: [],
     
     allSegmentsChanged: 0,

--- a/packages/timeline/test/test.tsx
+++ b/packages/timeline/test/test.tsx
@@ -4,9 +4,13 @@ import { ClapSegmentCategory } from "@aitube/clap"
 import { useTimeline } from "../src/hooks/useTimeline"
 import { getDefaultState } from "../src/utils/getDefaultState"
 
+const resetTimeline = () => {
+  useTimeline.setState(getDefaultState())
+}
+
 describe("timeline track and clip creation", () => {
   it("creates an empty track and recomputes timeline content", () => {
-    useTimeline.setState(getDefaultState(), true)
+    resetTimeline()
 
     const trackId = useTimeline.getState().createTrack({
       name: "Dialogue",
@@ -21,7 +25,7 @@ describe("timeline track and clip creation", () => {
   })
 
   it("creates a clip on a new track when no track is requested", async () => {
-    useTimeline.setState(getDefaultState(), true)
+    resetTimeline()
 
     const clip = await useTimeline.getState().createClip({
       category: ClapSegmentCategory.SOUND,
@@ -40,7 +44,7 @@ describe("timeline track and clip creation", () => {
   })
 
   it("reuses an existing same-category track when it has room", async () => {
-    useTimeline.setState(getDefaultState(), true)
+    resetTimeline()
     const trackId = useTimeline.getState().createTrack({
       name: "IMAGE",
       category: ClapSegmentCategory.IMAGE,
@@ -60,7 +64,7 @@ describe("timeline track and clip creation", () => {
   })
 
   it("creates a clip on a requested track and materializes missing tracks", async () => {
-    useTimeline.setState(getDefaultState(), true)
+    resetTimeline()
 
     const clip = await useTimeline.getState().createClip({
       category: ClapSegmentCategory.IMAGE,
@@ -76,7 +80,7 @@ describe("timeline track and clip creation", () => {
   })
 
   it("sets an empty track category from the track selector", () => {
-    useTimeline.setState(getDefaultState(), true)
+    resetTimeline()
     const trackId = useTimeline.getState().createTrack()
 
     const changed = useTimeline.getState().setTrackCategory({
@@ -92,7 +96,7 @@ describe("timeline track and clip creation", () => {
   })
 
   it("moves a clip along the timeline and onto a same-category track", async () => {
-    useTimeline.setState(getDefaultState(), true)
+    resetTimeline()
     const firstTrack = useTimeline.getState().createTrack({
       category: ClapSegmentCategory.SOUND,
     })
@@ -123,7 +127,7 @@ describe("timeline track and clip creation", () => {
   })
 
   it("rejects moving a clip to a different track category", async () => {
-    useTimeline.setState(getDefaultState(), true)
+    resetTimeline()
     const soundTrack = useTimeline.getState().createTrack({
       category: ClapSegmentCategory.SOUND,
     })

--- a/packages/timeline/test/test.tsx
+++ b/packages/timeline/test/test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test"
+import { ClapSegmentCategory } from "@aitube/clap"
+
+import { useTimeline } from "../src/hooks/useTimeline"
+import { getDefaultState } from "../src/utils/getDefaultState"
+
+describe("timeline track and clip creation", () => {
+  it("creates an empty track and recomputes timeline content", () => {
+    useTimeline.setState(getDefaultState(), true)
+
+    const trackId = useTimeline.getState().createTrack({
+      name: "Dialogue",
+      category: ClapSegmentCategory.DIALOGUE,
+    })
+
+    const state = useTimeline.getState()
+    expect(trackId).toBe(0)
+    expect(state.tracks[trackId].name).toBe("Dialogue")
+    expect(state.tracks[trackId].occupied).toBe(false)
+    expect(state.contentHeight).toBeGreaterThan(0)
+  })
+
+  it("creates a clip on a new track when no track is requested", async () => {
+    useTimeline.setState(getDefaultState(), true)
+
+    const clip = await useTimeline.getState().createClip({
+      category: ClapSegmentCategory.SOUND,
+      startTimeInMs: 1000,
+      durationInMs: 2500,
+      label: "Door knock",
+    })
+
+    const state = useTimeline.getState()
+    expect(state.segments).toHaveLength(1)
+    expect(state.segments[0].id).toBe(clip.id)
+    expect(clip.track).toBe(0)
+    expect(clip.startTimeInMs).toBe(1000)
+    expect(clip.endTimeInMs).toBe(3500)
+    expect(state.tracks[clip.track].name).toBe("SOUND")
+  })
+
+  it("reuses an existing same-category track when it has room", async () => {
+    useTimeline.setState(getDefaultState(), true)
+    const trackId = useTimeline.getState().createTrack({
+      name: "IMAGE",
+      category: ClapSegmentCategory.IMAGE,
+    })
+
+    const clip = await useTimeline.getState().createClip({
+      category: ClapSegmentCategory.IMAGE,
+      startTimeInMs: 1000,
+      durationInMs: 1000,
+      label: "Storyboard frame",
+    })
+
+    const state = useTimeline.getState()
+    expect(clip.track).toBe(trackId)
+    expect(state.tracks[trackId].occupied).toBe(true)
+    expect(state.segments[0].track).toBe(trackId)
+  })
+
+  it("creates a clip on a requested track and materializes missing tracks", async () => {
+    useTimeline.setState(getDefaultState(), true)
+
+    const clip = await useTimeline.getState().createClip({
+      category: ClapSegmentCategory.IMAGE,
+      track: 4,
+      label: "Storyboard frame",
+    })
+
+    const state = useTimeline.getState()
+    expect(clip.track).toBe(4)
+    expect(state.tracks[4].name).toBe("IMAGE")
+    expect(state.tracks[4].isPreview).toBe(true)
+    expect(state.segments[0].track).toBe(4)
+  })
+})

--- a/packages/timeline/test/test.tsx
+++ b/packages/timeline/test/test.tsx
@@ -2,10 +2,42 @@ import { describe, expect, it } from "bun:test"
 import { ClapSegmentCategory } from "@aitube/clap"
 
 import { useTimeline } from "../src/hooks/useTimeline"
+import { SegmentPointerEvent } from "../src/types/timeline"
 import { getDefaultState } from "../src/utils/getDefaultState"
 
 const resetTimeline = () => {
   useTimeline.setState(getDefaultState())
+}
+
+const makePointerEvent = ({
+  timestampInMs,
+  track,
+  buttons = 1,
+}: {
+  timestampInMs: number
+  track: number
+  buttons?: number
+}) => {
+  const state = useTimeline.getState()
+  const pointX = ((timestampInMs / state.durationInMsPerStep) * state.cellWidth) - (state.containerWidth / 2)
+  const cursorY = state.getVerticalCellPosition(0, track) + (state.getCellHeight(track) / 2)
+  const pointY = (state.contentHeight / 2) - cursorY
+
+  return {
+    buttons,
+    offsetX: 200,
+    offsetY: 200,
+    pointerId: 1,
+    point: {
+      x: pointX,
+      y: pointY,
+    },
+    stopPropagation: () => {},
+    target: {
+      setPointerCapture: () => {},
+      releasePointerCapture: () => {},
+    },
+  } as any
 }
 
 describe("timeline track and clip creation", () => {
@@ -229,5 +261,55 @@ describe("timeline track and clip creation", () => {
     expect(moved).toBeUndefined()
     expect(state.segments[0].track).toBe(soundTrack)
     expect(state.segments[0].startTimeInMs).toBe(1000)
+  })
+
+  it("preserves the grabbed clip offset during pointer drag", async () => {
+    resetTimeline()
+    const firstTrack = useTimeline.getState().createTrack({
+      category: ClapSegmentCategory.SOUND,
+    })
+    const secondTrack = useTimeline.getState().createTrack({
+      category: ClapSegmentCategory.SOUND,
+    })
+
+    const clip = await useTimeline.getState().createClip({
+      category: ClapSegmentCategory.SOUND,
+      track: firstTrack,
+      startTimeInMs: 1000,
+      durationInMs: 2000,
+    })
+
+    useTimeline.getState().handleSegmentEvent({
+      eventType: SegmentPointerEvent.DOWN,
+      segment: clip,
+    })(makePointerEvent({
+      timestampInMs: 1500,
+      track: firstTrack,
+    }))
+
+    expect(useTimeline.getState().segmentDragOffsetInMs).toBe(500)
+
+    useTimeline.getState().handleSegmentEvent({
+      eventType: SegmentPointerEvent.MOVE,
+      segment: clip,
+    })(makePointerEvent({
+      timestampInMs: 4500,
+      track: secondTrack,
+    }))
+
+    useTimeline.getState().handleSegmentEvent({
+      eventType: SegmentPointerEvent.UP,
+      segment: clip,
+    })(makePointerEvent({
+      timestampInMs: 4500,
+      track: secondTrack,
+      buttons: 0,
+    }))
+
+    const state = useTimeline.getState()
+    expect(state.segmentDragOffsetInMs).toBe(0)
+    expect(state.segments[0].track).toBe(secondTrack)
+    expect(state.segments[0].startTimeInMs).toBe(4000)
+    expect(state.segments[0].endTimeInMs).toBe(6000)
   })
 })

--- a/packages/timeline/test/test.tsx
+++ b/packages/timeline/test/test.tsx
@@ -74,4 +74,79 @@ describe("timeline track and clip creation", () => {
     expect(state.tracks[4].isPreview).toBe(true)
     expect(state.segments[0].track).toBe(4)
   })
+
+  it("sets an empty track category from the track selector", () => {
+    useTimeline.setState(getDefaultState(), true)
+    const trackId = useTimeline.getState().createTrack()
+
+    const changed = useTimeline.getState().setTrackCategory({
+      trackId,
+      category: ClapSegmentCategory.VIDEO,
+    })
+
+    const state = useTimeline.getState()
+    expect(changed).toBe(true)
+    expect(state.tracks[trackId].name).toBe("VIDEO")
+    expect(state.tracks[trackId].isPreview).toBe(true)
+    expect(state.tracks[trackId].height).toBe(state.defaultPreviewHeight)
+  })
+
+  it("moves a clip along the timeline and onto a same-category track", async () => {
+    useTimeline.setState(getDefaultState(), true)
+    const firstTrack = useTimeline.getState().createTrack({
+      category: ClapSegmentCategory.SOUND,
+    })
+    const secondTrack = useTimeline.getState().createTrack({
+      category: ClapSegmentCategory.SOUND,
+    })
+
+    const clip = await useTimeline.getState().createClip({
+      category: ClapSegmentCategory.SOUND,
+      track: firstTrack,
+      startTimeInMs: 1000,
+      durationInMs: 2000,
+    })
+
+    const moved = useTimeline.getState().moveClip({
+      segmentId: clip.id,
+      startTimeInMs: 4000,
+      track: secondTrack,
+    })
+
+    const state = useTimeline.getState()
+    expect(moved?.track).toBe(secondTrack)
+    expect(moved?.startTimeInMs).toBe(4000)
+    expect(moved?.endTimeInMs).toBe(6000)
+    expect(state.segments[0].track).toBe(secondTrack)
+    expect(state.tracks[firstTrack].occupied).toBe(false)
+    expect(state.tracks[secondTrack].occupied).toBe(true)
+  })
+
+  it("rejects moving a clip to a different track category", async () => {
+    useTimeline.setState(getDefaultState(), true)
+    const soundTrack = useTimeline.getState().createTrack({
+      category: ClapSegmentCategory.SOUND,
+    })
+    const imageTrack = useTimeline.getState().createTrack({
+      category: ClapSegmentCategory.IMAGE,
+    })
+
+    const clip = await useTimeline.getState().createClip({
+      category: ClapSegmentCategory.SOUND,
+      track: soundTrack,
+      startTimeInMs: 1000,
+      durationInMs: 2000,
+    })
+
+    const moved = useTimeline.getState().moveClip({
+      segmentId: clip.id,
+      startTimeInMs: 4000,
+      track: imageTrack,
+    })
+
+    const state = useTimeline.getState()
+    expect(moved).toBeUndefined()
+    expect(state.segments[0].track).toBe(soundTrack)
+    expect(state.segments[0].startTimeInMs).toBe(1000)
+  })
 })

--- a/packages/timeline/test/test.tsx
+++ b/packages/timeline/test/test.tsx
@@ -95,6 +95,30 @@ describe("timeline track and clip creation", () => {
     expect(state.tracks[trackId].height).toBe(state.defaultPreviewHeight)
   })
 
+  it("rejects changing an occupied track to an incompatible category", async () => {
+    resetTimeline()
+    const trackId = useTimeline.getState().createTrack({
+      category: ClapSegmentCategory.SOUND,
+    })
+
+    await useTimeline.getState().createClip({
+      category: ClapSegmentCategory.SOUND,
+      track: trackId,
+      startTimeInMs: 1000,
+      durationInMs: 2000,
+    })
+
+    const changed = useTimeline.getState().setTrackCategory({
+      trackId,
+      category: ClapSegmentCategory.IMAGE,
+    })
+
+    const state = useTimeline.getState()
+    expect(changed).toBe(false)
+    expect(state.tracks[trackId].name).toBe("SOUND")
+    expect(state.segments[0].category).toBe(ClapSegmentCategory.SOUND)
+  })
+
   it("moves a clip along the timeline and onto a same-category track", async () => {
     resetTimeline()
     const firstTrack = useTimeline.getState().createTrack({
@@ -124,6 +148,59 @@ describe("timeline track and clip creation", () => {
     expect(state.segments[0].track).toBe(secondTrack)
     expect(state.tracks[firstTrack].occupied).toBe(false)
     expect(state.tracks[secondTrack].occupied).toBe(true)
+  })
+
+  it("clamps leftward clip movement at zero while preserving duration", async () => {
+    resetTimeline()
+    const trackId = useTimeline.getState().createTrack({
+      category: ClapSegmentCategory.SOUND,
+    })
+
+    const clip = await useTimeline.getState().createClip({
+      category: ClapSegmentCategory.SOUND,
+      track: trackId,
+      startTimeInMs: 1000,
+      durationInMs: 2000,
+    })
+
+    const moved = useTimeline.getState().moveClip({
+      segmentId: clip.id,
+      startTimeInMs: -500,
+      track: trackId,
+    })
+
+    expect(moved?.startTimeInMs).toBe(0)
+    expect(moved?.endTimeInMs).toBe(2000)
+  })
+
+  it("rejects moving a clip into an overlapping same-category slot", async () => {
+    resetTimeline()
+    const trackId = useTimeline.getState().createTrack({
+      category: ClapSegmentCategory.SOUND,
+    })
+
+    const firstClip = await useTimeline.getState().createClip({
+      category: ClapSegmentCategory.SOUND,
+      track: trackId,
+      startTimeInMs: 1000,
+      durationInMs: 2000,
+    })
+    await useTimeline.getState().createClip({
+      category: ClapSegmentCategory.SOUND,
+      track: trackId,
+      startTimeInMs: 5000,
+      durationInMs: 1000,
+    })
+
+    const moved = useTimeline.getState().moveClip({
+      segmentId: firstClip.id,
+      startTimeInMs: 4500,
+      track: trackId,
+    })
+
+    const state = useTimeline.getState()
+    expect(moved).toBeUndefined()
+    expect(state.segments.find((segment) => segment.id === firstClip.id)?.startTimeInMs).toBe(1000)
   })
 
   it("rejects moving a clip to a different track category", async () => {


### PR DESCRIPTION
Closes #10

## Summary

- Add timeline store APIs for creating tracks and clips programmatically.
- Materialize missing intermediate tracks when a requested track id is beyond the current track list.
- Reuse visible same-category tracks for new clips when the target time range has room.
- Mark existing tracks as occupied when a clip is assigned to them and update empty-track labels to the clip category.
- Add a compact left-bar `+` control for creating a new empty track directly in the timeline UI.
- Add a left-track dropdown for setting editable track categories.
- Add a timeline UI entry point: double-clicking the empty timeline plane creates a clip at the cursor time and on the clicked track/category.
- Add same-category clip movement support with collision rejection for timeline drag interactions.
- Preserve the grab offset during pointer drag so clips move from the point the user picked up instead of jumping to the pointer center.
- Capture and release the pointer during clip drags so the drag can continue while the cursor crosses clip-edge hit areas.
- Add Bun tests for creating empty tracks, creating clips, setting track categories, moving clips, pointer-drag movement, clamping negative movement, rejecting overlap, and rejecting cross-category/category-change moves.
- Fix the local `@aitube/clap` workspace entrypoint/type exports so Bun can resolve the monorepo package during tests.

## Validation

- `npx --yes bun --no-install test ./packages/timeline/test/test.tsx` passed on head `93bde53`: 11 tests, 42 assertions.
- `git diff --check main...HEAD` passed.

## Scope

This adds the store/API foundation for timeline track and clip creation, a direct add-track control, a track category dropdown, double-click clip creation, same-category movement support, pointer-drag behavior that preserves the grabbed offset, and guard coverage for invalid category changes, overlap, and negative movement. Richer clip authoring controls can build on these APIs separately.