### PR TITLE
feat(timeline): support dynamic tracks and clips

### DIFF
--- a/packages/clap/src/types.ts
+++ b/packages/clap/src/types.ts
@@ -959,6 +959,11 @@ export type ClapEntity = {
 export type ClapTrack = {
   id: number
   name: string
+  /**
+   * Optional media constraint for timeline editors. It remains optional so
+   * older .clap projects with untyped tracks continue to load unchanged.
+   */
+  type?: ClapSegmentCategory
   isPreview: boolean
   height: number
   hue: number

--- a/packages/timeline/src/ClapTimeline.tsx
+++ b/packages/timeline/src/ClapTimeline.tsx
@@ -5,7 +5,8 @@ import { Stats } from "@react-three/drei"
 import {
   TimelineControls,
   HorizontalScroller,
-  Timeline
+  Timeline,
+  TimelineToolbar
 } from "@/components"
 import { ClapProject, isValidNumber } from "@aitube/clap"
 import {
@@ -122,6 +123,7 @@ export function ClapTimeline({
       <div className="flex flex-grow flex-row w-full h-full">
         <div className="flex flex-grow flex-col w-full h-full">
           <HorizontalScroller />
+          <TimelineToolbar />
           <Canvas
             ref={(canvas) => {
               setCanvas(canvas || undefined)

--- a/packages/timeline/src/components/index.ts
+++ b/packages/timeline/src/components/index.ts
@@ -10,3 +10,4 @@ export {
 export { TimelineControls } from "./controls"
 export { HorizontalScroller, VerticalScroller } from "./scroller"
 export { Timeline, TopBarTimeScale, Cells, Grid, type JumpAt } from "./timeline"
+export { TimelineToolbar } from "./timeline/TimelineToolbar"

--- a/packages/timeline/src/components/timeline/Timeline.tsx
+++ b/packages/timeline/src/components/timeline/Timeline.tsx
@@ -22,11 +22,22 @@ export function Timeline({ width, height }: { width: number; height: number }) {
 
   const contentHeight = useTimeline(s => s.contentHeight)
   const contentWidth = useTimeline(s => s.contentWidth)
+  const moveSegmentAtPoint = useTimeline(s => s.moveSegmentAtPoint)
+  const setEditedSegment = useTimeline(s => s.setEditedSegment)
 
   // console.log(`re-rendering <Timeline>`)
   return (
     <mesh
       position={[0,0,0]}
+      onPointerMove={(event) => {
+        moveSegmentAtPoint({
+          worldX: event.point.x,
+          worldY: event.point.y,
+        })
+      }}
+      onPointerUp={() => {
+        setEditedSegment({ segment: undefined })
+      }}
     >
       <Plane
         args={[contentWidth, contentHeight]}

--- a/packages/timeline/src/components/timeline/TimelineToolbar.tsx
+++ b/packages/timeline/src/components/timeline/TimelineToolbar.tsx
@@ -1,0 +1,116 @@
+import { useState, type CSSProperties } from "react"
+import { ClapSegmentCategory } from "@aitube/clap"
+
+import { useTimeline } from "@/hooks"
+
+const trackTypeOptions: Array<{ label: string; value: ClapSegmentCategory }> = [
+  { label: "Video", value: ClapSegmentCategory.VIDEO },
+  { label: "Image", value: ClapSegmentCategory.IMAGE },
+  { label: "Dialogue", value: ClapSegmentCategory.DIALOGUE },
+  { label: "Sound", value: ClapSegmentCategory.SOUND },
+  { label: "Music", value: ClapSegmentCategory.MUSIC },
+  { label: "Generic", value: ClapSegmentCategory.GENERIC },
+]
+
+const toolbarStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+  padding: "8px 10px",
+  color: "#f5f5f4",
+  background: "#18181b",
+  borderBottom: "1px solid #3f3f46",
+  fontSize: 12,
+}
+
+const rowStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  flexWrap: "wrap",
+  gap: 8,
+}
+
+const selectStyle: CSSProperties = {
+  color: "#f5f5f4",
+  background: "#27272a",
+  border: "1px solid #52525b",
+  borderRadius: 4,
+  padding: "3px 6px",
+}
+
+const buttonStyle: CSSProperties = {
+  color: "#18181b",
+  background: "#facc15",
+  border: 0,
+  borderRadius: 4,
+  padding: "4px 8px",
+  cursor: "pointer",
+  fontWeight: 600,
+}
+
+export function TimelineToolbar() {
+  const tracks = useTimeline(s => s.tracks)
+  const addTrack = useTimeline(s => s.addTrack)
+  const setTrackType = useTimeline(s => s.setTrackType)
+  const createClip = useTimeline(s => s.createClip)
+  const [newTrackType, setNewTrackType] = useState<ClapSegmentCategory>(ClapSegmentCategory.VIDEO)
+
+  return (
+    <div style={toolbarStyle} data-testid="timeline-toolbar">
+      <div style={rowStyle}>
+        <strong>Timeline tracks</strong>
+        <label>
+          New track type{" "}
+          <select
+            aria-label="New track type"
+            style={selectStyle}
+            value={newTrackType}
+            onChange={event => setNewTrackType(event.target.value as ClapSegmentCategory)}
+          >
+            {trackTypeOptions.map(option => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() => addTrack({ type: newTrackType })}
+        >
+          + Track
+        </button>
+      </div>
+      <div style={rowStyle}>
+        {tracks.map(track => (
+          <div key={track.id} style={rowStyle}>
+            <span>Track {track.id}</span>
+            <select
+              aria-label={`Track ${track.id} type`}
+              style={selectStyle}
+              value={track.type || ""}
+              onChange={event => setTrackType({
+                trackId: track.id,
+                type: event.target.value
+                  ? event.target.value as ClapSegmentCategory
+                  : undefined,
+              })}
+            >
+              <option value="">Unassigned</option>
+              {trackTypeOptions.map(option => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+            <button
+              type="button"
+              style={buttonStyle}
+              aria-label={`Add clip to track ${track.id}`}
+              onClick={() => void createClip({ track: track.id })}
+            >
+              + Clip
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/timeline/src/hooks/useTimeline.ts
+++ b/packages/timeline/src/hooks/useTimeline.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand"
 import * as THREE from "three"
 import type { ThreeEvent } from "@react-three/fiber"
-import { ClapProject, ClapSegment, ClapSegmentCategory, isValidNumber, newClap, serializeClap, ClapTracks, ClapEntity, ClapMeta } from "@aitube/clap"
+import { ClapProject, ClapSegment, ClapSegmentCategory, isValidNumber, newClap, newSegment, serializeClap, ClapTracks, ClapEntity, ClapMeta } from "@aitube/clap"
 
 import { TimelineSegment, SegmentEditionStatus, SegmentVisibility, TimelineStore, SegmentArea, SegmentPointerEvent, SegmentEventCallbackHandler, Invalidate } from "@/types/timeline"
 import { getDefaultProjectState, getDefaultState } from "@/utils/getDefaultState"
@@ -129,6 +129,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
           id: segment.track,
           // name: `Track ${s.track}`,
           name: `${segment.category}`,
+          type: segment.category,
           isPreview,
           height:
             isPreview
@@ -143,6 +144,10 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         const track = tracks[segment.track]
         const categories: string[] = track.name.split(",").map((x: string) => x.trim())
         if (!categories.includes(segment.category)) {
+          // Tracks from older projects may contain mixed media. Keep those
+          // tracks untyped rather than silently applying the first category
+          // as a restriction.
+          track.type = undefined
           tracks[segment.track].name = "(misc)"
 
           /*
@@ -730,6 +735,237 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       })
     })
   },
+  addTrack: ({ type, name }: { type?: ClapSegmentCategory; name?: string } = {}) => {
+    const {
+      width,
+      height,
+      tracks,
+      cellWidth,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs,
+      defaultPreviewHeight,
+      defaultCellHeight,
+    } = get()
+
+    const id = tracks.length
+    const isPreview = type === ClapSegmentCategory.IMAGE || type === ClapSegmentCategory.VIDEO
+    const nextTracks = tracks.concat({
+      id,
+      name: name || type || `Track ${id}`,
+      type,
+      isPreview,
+      height: isPreview ? defaultPreviewHeight : defaultCellHeight,
+      hue: 0,
+      occupied: false,
+      visible: true,
+    })
+
+    set({
+      ...computeContentSizeMetrics({
+        width,
+        height,
+        tracks: nextTracks,
+        cellWidth,
+        defaultSegmentDurationInSteps,
+        durationInMsPerStep,
+        durationInMs,
+      }),
+      allSegmentsChanged: get().allSegmentsChanged + 1,
+    })
+
+    return id
+  },
+  setTrackType: ({ trackId, type }: { trackId: number; type?: ClapSegmentCategory }) => {
+    const {
+      width,
+      height,
+      tracks,
+      segments,
+      cellWidth,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs,
+      defaultPreviewHeight,
+      defaultCellHeight,
+    } = get()
+
+    const track = tracks.find(current => current.id === trackId)
+    if (!track) return
+
+    const hasIncompatibleSegments = segments.some(
+      segment => segment.track === trackId && type && segment.category !== type
+    )
+    if (hasIncompatibleSegments) return
+
+    const isPreview = type === ClapSegmentCategory.IMAGE || type === ClapSegmentCategory.VIDEO
+    const nextTracks = tracks.map(current => current.id === trackId
+      ? {
+          ...current,
+          type,
+          name: type || "(empty)",
+          isPreview: type ? isPreview : current.isPreview,
+          height: type ? (isPreview ? defaultPreviewHeight : defaultCellHeight) : current.height,
+          occupied: segments.some(segment => segment.track === trackId),
+        }
+      : current
+    )
+
+    set({
+      ...computeContentSizeMetrics({
+        width,
+        height,
+        tracks: nextTracks,
+        cellWidth,
+        defaultSegmentDurationInSteps,
+        durationInMsPerStep,
+        durationInMs,
+      }),
+      allSegmentsChanged: get().allSegmentsChanged + 1,
+    })
+  },
+  createClip: async ({
+    track: trackId,
+    startTimeInMs = 0,
+    durationInMs: requestedDurationInMs,
+    label,
+  }: {
+    track: number
+    startTimeInMs?: number
+    durationInMs?: number
+    label?: string
+  }) => {
+    const { tracks, durationInMsPerStep, addSegment } = get()
+    const track = tracks.find(current => current.id === trackId)
+    if (!track) return
+
+    const category = track.type || ClapSegmentCategory.GENERIC
+    const duration = Math.max(
+      requestedDurationInMs || durationInMsPerStep * 4,
+      durationInMsPerStep * 2
+    )
+    const safeStartTimeInMs = Math.max(0, startTimeInMs)
+    const segment = newSegment({
+      track: trackId,
+      category,
+      startTimeInMs: safeStartTimeInMs,
+      endTimeInMs: safeStartTimeInMs + duration,
+      label: label || `${category} clip`,
+      prompt: label || `${category} clip`,
+    })
+
+    await addSegment({
+      segment: segment as TimelineSegment,
+      track: trackId,
+    })
+  },
+  moveSegment: ({
+    segmentId,
+    startTimeInMs,
+    track: trackId,
+  }: {
+    segmentId: string
+    startTimeInMs: number
+    track: number
+  }) => {
+    const {
+      width,
+      height,
+      segments,
+      tracks,
+      cellWidth,
+      defaultSegmentDurationInSteps,
+      durationInMsPerStep,
+      durationInMs: previousDurationInMs,
+    } = get()
+
+    const segment = segments.find(candidate => candidate.id === segmentId)
+    const targetTrack = tracks.find(candidate => candidate.id === trackId)
+    if (!segment || !targetTrack) return false
+    if (targetTrack.type && targetTrack.type !== segment.category) return false
+
+    const segmentDuration = segment.endTimeInMs - segment.startTimeInMs
+    const movedSegment = {
+      ...segment,
+      startTimeInMs: Math.max(0, Math.round(startTimeInMs)),
+      endTimeInMs: Math.max(0, Math.round(startTimeInMs)) + segmentDuration,
+      track: trackId,
+    }
+    const nextSegments = segments.map(candidate => candidate.id === segmentId ? movedSegment : candidate)
+    const targetWasEmpty = !targetTrack.occupied && !segments.some(candidate => candidate.track === trackId)
+    const adoptedType = targetTrack.type || (targetWasEmpty ? segment.category : undefined)
+    const nextTracks = tracks.map(current => {
+      const occupied = nextSegments.some(candidate => candidate.track === current.id)
+      if (current.id === trackId && targetWasEmpty) {
+        const isPreview = segment.category === ClapSegmentCategory.IMAGE || segment.category === ClapSegmentCategory.VIDEO
+        return {
+          ...current,
+          type: adoptedType,
+          name: `${segment.category}`,
+          isPreview,
+          height: isPreview ? get().defaultPreviewHeight : get().defaultCellHeight,
+          occupied,
+        }
+      }
+      return { ...current, occupied }
+    })
+    const nextDurationInMs = Math.max(
+      previousDurationInMs,
+      ...nextSegments.map(candidate => candidate.endTimeInMs),
+    )
+
+    set({
+      segments: nextSegments,
+      loadedSegments: [],
+      allSegmentsChanged: get().allSegmentsChanged + 1,
+      atLeastOneSegmentChanged: get().atLeastOneSegmentChanged + 1,
+      durationInMs: nextDurationInMs,
+      ...computeContentSizeMetrics({
+        width,
+        height,
+        tracks: nextTracks,
+        cellWidth,
+        defaultSegmentDurationInSteps,
+        durationInMsPerStep,
+        durationInMs: nextDurationInMs,
+      }),
+    })
+
+    return true
+  },
+  moveSegmentAtPoint: ({ worldX, worldY }: { worldX: number; worldY: number }) => {
+    const {
+      editedSegment,
+      contentHeight,
+      containerWidth,
+      cellWidth,
+      durationInMsPerStep,
+      tracks,
+      moveSegment,
+    } = get()
+
+    if (!editedSegment || editedSegment.editionStatus !== SegmentEditionStatus.DRAGGING) return
+
+    const timelineX = worldX + containerWidth / 2
+    const duration = editedSegment.endTimeInMs - editedSegment.startTimeInMs
+    const pointerTimeInMs = (timelineX / cellWidth) * durationInMsPerStep
+    const startTimeInMs = pointerTimeInMs - duration / 2
+    const localY = contentHeight / 2 - worldY
+
+    let trackId = tracks[0]?.id ?? 0
+    let accumulatedHeight = 0
+    for (const track of tracks) {
+      const trackHeight = track.height || get().defaultCellHeight
+      if (localY <= accumulatedHeight + trackHeight) {
+        trackId = track.id
+        break
+      }
+      accumulatedHeight += trackHeight
+      trackId = track.id
+    }
+
+    moveSegment({ segmentId: editedSegment.id, startTimeInMs, track: trackId })
+  },
   setContainerSize: ({ width, height }: { width: number; height: number }) => {
     const { containerWidth: previousWidth, containerHeight: previousHeight } = get()
     const changed = 
@@ -891,11 +1127,17 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       durationInMsPerStep,
       durationInMs,
       tracks,
+      segments,
       defaultPreviewHeight,
       defaultCellHeight,
       atLeastOneSegmentChanged: previousAtLeastOneSegmentChanged,
       allSegmentsChanged: previousAllSegmentsChanged,
     } = get()
+
+    const targetTrack = tracks[track]
+    if (targetTrack?.type && targetTrack.type !== segment.category) {
+      return
+    }
 
     segment.track = track
    
@@ -911,6 +1153,7 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         id: segment.track,
         // name: `Track ${s.track}`,
         name: `${segment.category}`,
+        type: segment.category,
         isPreview,
         height:
           isPreview
@@ -920,6 +1163,12 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
         occupied: true,
         visible: true,
       }
+    } else if (!tracks[segment.track].type && !tracks[segment.track].occupied && !segments.some(s => s.track === segment.track)) {
+      tracks[segment.track].type = segment.category
+      tracks[segment.track].name = `${segment.category}`
+      tracks[segment.track].isPreview =
+        segment.category === ClapSegmentCategory.IMAGE ||
+        segment.category === ClapSegmentCategory.VIDEO
     }
 
     if (triggerChange) {
@@ -978,6 +1227,11 @@ export const useTimeline = create<TimelineStore>((set, get) => ({
       startTimeInMs,
       endTimeInMs
     })
+
+    const requestedTargetTrack = tracks[availableTrack]
+    if (requestedTargetTrack?.type && requestedTargetTrack.type !== segment.category) {
+      return
+    }
 
     /*
     console.log("availableTrack:", {

--- a/packages/timeline/src/index.tsx
+++ b/packages/timeline/src/index.tsx
@@ -3,6 +3,7 @@ export {
   HorizontalScroller,
   VerticalScroller,
   Timeline,
+  TimelineToolbar,
   TopBarTimeScale,
   Cells,
   Grid,

--- a/packages/timeline/src/types/timeline.ts
+++ b/packages/timeline/src/types/timeline.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three"
 import type { ThreeEvent } from "@react-three/fiber"
-import { ClapEntity, ClapImageRatio, ClapMeta, ClapProject, ClapScene, ClapSegment, ClapTracks } from "@aitube/clap"
+import { ClapEntity, ClapImageRatio, ClapMeta, ClapProject, ClapScene, ClapSegment, ClapSegmentCategory, ClapTracks } from "@aitube/clap"
 
 import { ClapSegmentColorScheme, ClapTimelineTheme } from "./theme"
 import { TimelineControlsImpl } from "@/components/controls/types"
@@ -327,6 +327,20 @@ export type TimelineStoreModifiers = {
   setScrollX: (scrollX: number) => void
   handleMouseWheel: ({ deltaX, deltaY }: { deltaX: number; deltaY: number }) => void
   toggleTrackVisibility: (trackId: number) => void
+  addTrack: (params?: { type?: ClapSegmentCategory; name?: string }) => number
+  setTrackType: (params: { trackId: number; type?: ClapSegmentCategory }) => void
+  createClip: (params: {
+    track: number
+    startTimeInMs?: number
+    durationInMs?: number
+    label?: string
+  }) => Promise<void>
+  moveSegment: (params: {
+    segmentId: string
+    startTimeInMs: number
+    track: number
+  }) => boolean
+  moveSegmentAtPoint: (params: { worldX: number; worldY: number }) => void
   setContainerSize: ({ width, height }: { width: number; height: number }) => void
   setTimelineCursor: (timelineCursor?: TimelineCursorImpl) => void
   setIsDraggingCursor: (isDraggingCursor: boolean) => void


### PR DESCRIPTION
Closes #10

This implements dynamic timeline tracks and clips:

- Create tracks with an optional media type.
- Change a track's type from an accessible dropdown.
- Create clips on a selected track using its type.
- Drag clips along the timeline and between compatible tracks.
- Reject incompatible track moves and preserve backwards compatibility for legacy or mixed tracks.

Validation:
- TypeScript transpilation completed for all 8 changed files.
- Changed-file type diagnostics are clean.
- Full repository build was not run because Bun is unavailable in the environment.

The PR is intentionally limited to the timeline behavior requested by the issue.